### PR TITLE
Ignore `go.work` and `go.work.sum`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ Cargo.lock
 package-lock.json
 yarn.lock
 go.sum
+go.work
+go.work.sum


### PR DESCRIPTION
Those files are usefull to have locally to open `graph-networks-libs` directly in VSCode and get the overall `gopls` to work properly.