### PR TITLE
v0.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,135 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  rust:
+    name: Rust
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          components: rustfmt, clippy
+
+      - name: Cache dependencies
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            packages/rust/target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Check formatting
+        working-directory: ./packages/rust
+        run: cargo fmt -- --check
+
+      - name: Lint with clippy
+        working-directory: ./packages/rust
+        run: cargo clippy -- -D warnings
+
+      - name: Run tests
+        working-directory: ./packages/rust
+        run: cargo test
+
+      - name: Build local example
+        working-directory: ./packages/rust/examples/local
+        run: cargo build
+
+      - name: Build fetch example
+        working-directory: ./packages/rust/examples/fetch
+        run: cargo build
+
+  typescript:
+    name: TypeScript
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 22
+
+      - name: Cache dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+
+      - name: Install dependencies
+        working-directory: ./packages/typescript
+        run: npm ci
+
+      - name: Lint
+        working-directory: ./packages/typescript
+        run: npm run lint
+
+      - name: Run tests
+        working-directory: ./packages/typescript
+        run: npm test
+
+      - name: Build
+        working-directory: ./packages/typescript
+        run: npm run build
+
+      - name: Check examples
+        working-directory: ./packages/typescript/examples
+        run: npm ci && npm run build
+
+  golang:
+    name: Golang
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.21'
+
+      - name: Cache dependencies
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+
+      - name: Format check
+        working-directory: ./packages/golang
+        run: |
+          if [ -n "$(gofmt -l .)" ]; then
+            echo "Go files need formatting:"
+            gofmt -l .
+            exit 1
+          fi
+
+      - name: Install golangci-lint
+        run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.54.2
+
+      - name: Run linter
+        working-directory: ./packages/golang
+        run: $(go env GOPATH)/bin/golangci-lint run ./...
+
+      - name: Run tests
+        working-directory: ./packages/golang
+        run: go test ./...
+
+      - name: Build local example
+        working-directory: ./packages/golang/examples/local
+        run: go build
+
+      - name: Build fetch example
+        working-directory: ./packages/golang/examples/fetch
+        run: go build

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@ node_modules
 dist
 *.log
 .env
-bun.lockb
+bun.lock*
 temp-schema.json
 
 packages/rust/**/target

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The Graph Networks Registry Libraries
 
-[![npm version](https://badge.fury.io/js/%40pinax%2Fgraph-networks-registry.svg)](https://www.npmjs.com/package/@pinax/graph-networks-registry) [![Crates.io](https://img.shields.io/crates/v/graph-networks-registry.svg?label=crates.io%20crate)](https://crates.io/crates/graph-networks-registry) [![Go Module](https://img.shields.io/github/v/tag/pinax-network/graph-networks-libs?filter=packages/golang/*&label=go%20module&sort=semver)](https://pkg.go.dev/github.com/pinax-network/graph-networks-libs/packages/golang/lib)
+[![CI](https://github.com/pinax-network/graph-networks-libs/actions/workflows/ci.yml/badge.svg)](https://github.com/pinax-network/graph-networks-libs/actions/workflows/ci.yml) [![npm version](https://badge.fury.io/js/%40pinax%2Fgraph-networks-registry.svg)](https://www.npmjs.com/package/@pinax/graph-networks-registry) [![Crates.io](https://img.shields.io/crates/v/graph-networks-registry.svg?label=crates.io%20crate)](https://crates.io/crates/graph-networks-registry) [![Go Module](https://img.shields.io/github/v/tag/pinax-network/graph-networks-libs?filter=packages/golang/*&label=go%20module&sort=semver)](https://pkg.go.dev/github.com/pinax-network/graph-networks-libs/packages/golang/lib)
 
 Libraries to work with [The Graph Networks Registry](https://github.com/graphprotocol/networks-registry).
 

--- a/packages/golang/README.md
+++ b/packages/golang/README.md
@@ -30,9 +30,14 @@ func main() {
 
     fmt.Printf("Successfully loaded %d networks\n", len(reg.Networks))
 
-    // Get network by ID
-    if mainnet := reg.GetNetworkById("mainnet"); mainnet != nil {
+    // Get network by graph ID (works with both network ID and alias)
+    if mainnet := reg.GetNetworkByGraphId("mainnet"); mainnet != nil {
         fmt.Printf("Found mainnet: %s\n", mainnet.FullName)
+    }
+
+    // You can also use it to find networks by alias
+    if ethereum := reg.GetNetworkByGraphId("eth"); ethereum != nil {
+        fmt.Printf("Found ethereum by alias: %s\n", ethereum.FullName)
     }
 }
 ```
@@ -47,7 +52,7 @@ import (
 )
 
 func main() {
-    reg, err := registry.FromFile("TheGraphNetworksRegistry_v0_6_0.json")
+    reg, err := registry.FromFile("TheGraphNetworksRegistry_v0_7_0.json")
     if err != nil {
         log.Fatalf("Failed to load registry: %v", err)
     }
@@ -69,5 +74,6 @@ See reference on [pkg.go.dev](https://pkg.go.dev/github.com/pinax-network/graph-
 
 ### Methods
 
-- `GetNetworkById(id string) *Network` - Finds a network by ID
-- `GetNetworkByAlias(alias string) *Network` - Finds a network by ID or alias
+- `GetNetworkByGraphId(id string) *Network` - Finds a network by ID or alias (recommended)
+- `GetNetworkById(id string) *Network` - Finds a network by ID (deprecated)
+- `GetNetworkByAlias(alias string) *Network` - Finds a network by ID or alias (deprecated)

--- a/packages/golang/examples/fetch/go.mod
+++ b/packages/golang/examples/fetch/go.mod
@@ -4,4 +4,4 @@ go 1.22.0
 
 replace github.com/pinax-network/graph-networks-libs/packages/golang => ../..
 
-require github.com/pinax-network/graph-networks-libs/packages/golang v0.6.0
+require github.com/pinax-network/graph-networks-libs/packages/golang v0.7.0

--- a/packages/golang/examples/fetch/main.go
+++ b/packages/golang/examples/fetch/main.go
@@ -17,8 +17,13 @@ func main() {
 
     fmt.Printf("Successfully loaded %d networks\n", len(reg.Networks))
 
-    // Get network by ID
-    if mainnet := reg.GetNetworkById("mainnet"); mainnet != nil {
-        fmt.Printf("Found mainnet: %s\n", mainnet.FullName)
+    // Get network by graph ID (works with both network ID and alias)
+    if mainnet := reg.GetNetworkByGraphId("mainnet"); mainnet != nil {
+        fmt.Printf("Found mainnet by ID: %s\n", mainnet.FullName)
+    }
+
+    // You can also use the same method to find networks by alias
+    if ethereum := reg.GetNetworkByGraphId("eth"); ethereum != nil {
+        fmt.Printf("Found ethereum by alias: %s\n", ethereum.FullName)
     }
 }

--- a/packages/golang/examples/local/go.mod
+++ b/packages/golang/examples/local/go.mod
@@ -4,4 +4,4 @@ go 1.22.0
 
 replace github.com/pinax-network/graph-networks-libs/packages/golang => ../..
 
-require github.com/pinax-network/graph-networks-libs/packages/golang v0.6.0
+require github.com/pinax-network/graph-networks-libs/packages/golang v0.7.0

--- a/packages/golang/examples/local/main.go
+++ b/packages/golang/examples/local/main.go
@@ -24,4 +24,10 @@ func main() {
     if ethereum := reg.GetNetworkByGraphId("eth"); ethereum != nil {
         fmt.Printf("Found ethereum by alias: %s\n", ethereum.FullName)
     }
+
+    // Get network by CAIP-2 chain ID
+    if ethereum := reg.GetNetworkByCaip2Id("eip155:1"); ethereum != nil {
+        fmt.Printf("Found ethereum by CAIP-2 ID: %s (caip2Id: %s)\n", ethereum.FullName, ethereum.Caip2ID)
+    }
+
 }

--- a/packages/golang/examples/local/main.go
+++ b/packages/golang/examples/local/main.go
@@ -15,13 +15,13 @@ func main() {
     }
     fmt.Printf("Successfully loaded %d networks\n", len(reg.Networks))
 
-    // Get network by ID
-    if mainnet := reg.GetNetworkById("mainnet"); mainnet != nil {
-        fmt.Printf("Found mainnet: %s\n", mainnet.FullName)
+    // Get network by graph ID (works with both network ID and alias)
+    if mainnet := reg.GetNetworkByGraphId("mainnet"); mainnet != nil {
+        fmt.Printf("Found mainnet by ID: %s\n", mainnet.FullName)
     }
 
-    // Get network by alias
-    if ethereum := reg.GetNetworkByAlias("eth"); ethereum != nil {
+    // Get network by alias using the new unified method
+    if ethereum := reg.GetNetworkByGraphId("eth"); ethereum != nil {
         fmt.Printf("Found ethereum by alias: %s\n", ethereum.FullName)
     }
 }

--- a/packages/golang/lib/client.go
+++ b/packages/golang/lib/client.go
@@ -86,6 +86,8 @@ func FromFile(path string) (*NetworksRegistry, error) {
 // GetNetworkById finds a network by its unique identifier.
 // It takes a network ID string and returns the matching Network if found.
 // Returns nil if no network with the given ID exists in the registry.
+//
+// Deprecated: Use GetNetworkByGraphId instead, which handles both ID and alias lookup.
 func (r *NetworksRegistry) GetNetworkById(id string) *Network {
 	for i := range r.Networks {
 		if r.Networks[i].ID == id {
@@ -98,6 +100,8 @@ func (r *NetworksRegistry) GetNetworkById(id string) *Network {
 // GetNetworkByAlias finds a network by its ID or one of its aliases.
 // It takes an alias string and checks both network IDs and alias lists.
 // Returns the first matching Network or nil if no match is found.
+//
+// Deprecated: Use GetNetworkByGraphId instead, which handles both ID and alias lookup.
 func (r *NetworksRegistry) GetNetworkByAlias(alias string) *Network {
 	for i := range r.Networks {
 		network := &r.Networks[i]
@@ -107,6 +111,28 @@ func (r *NetworksRegistry) GetNetworkByAlias(alias string) *Network {
 		if network.Aliases != nil {
 			for _, a := range network.Aliases {
 				if a == alias {
+					return network
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// GetNetworkByGraphId finds a network by its unique identifier or one of its aliases.
+// It unifies the functionality of GetNetworkById and GetNetworkByAlias.
+// It takes a graph ID string (which can be either a network ID or an alias)
+// and returns the matching Network if found.
+// Returns nil if no network with the given ID or alias exists in the registry.
+func (r *NetworksRegistry) GetNetworkByGraphId(id string) *Network {
+	for i := range r.Networks {
+		network := &r.Networks[i]
+		if network.ID == id {
+			return network
+		}
+		if network.Aliases != nil {
+			for _, a := range network.Aliases {
+				if a == id {
 					return network
 				}
 			}

--- a/packages/golang/lib/client.go
+++ b/packages/golang/lib/client.go
@@ -141,6 +141,27 @@ func (r *NetworksRegistry) GetNetworkByGraphId(id string) *Network {
 	return nil
 }
 
+// GetNetworkByCaip2Id finds a network by its CAIP-2 chain ID.
+// It takes a chain ID string in the format "[namespace]:[reference]" (e.g., "eip155:1")
+// and returns the matching Network if found.
+// Returns nil if no network with the given CAIP-2 ID exists in the registry.
+// If the provided chainId doesn't contain a colon, it will print a warning message
+// suggesting the correct format.
+func (r *NetworksRegistry) GetNetworkByCaip2Id(chainId string) *Network {
+	if !strings.Contains(chainId, ":") {
+		fmt.Fprintf(os.Stderr, "Warning: CAIP-2 Chain ID should be in the format '[namespace]:[reference]', e.g., 'eip155:1'\n")
+		return nil
+	}
+
+	for i := range r.Networks {
+		network := &r.Networks[i]
+		if network.Caip2ID == chainId {
+			return network
+		}
+	}
+	return nil
+}
+
 func getMajorMinor() (string, string) {
 	parts := strings.Split(Version, ".")
 	if len(parts) < 2 {

--- a/packages/golang/lib/client_test.go
+++ b/packages/golang/lib/client_test.go
@@ -6,8 +6,8 @@ import (
 
 func TestNetworksRegistry(t *testing.T) {
     testRegistryJSON := `{
-        "$schema": "https://networks-registry.thegraph.com/TheGraphNetworksRegistrySchema_v0_6.json",
-        "version": "0.6.0",
+        "$schema": "https://networks-registry.thegraph.com/TheGraphNetworksRegistrySchema_v0_7.json",
+        "version": "0.7.0",
         "title": "Test Registry",
         "description": "Test Registry",
         "updatedAt": "2025-01-01T00:00:00Z",
@@ -34,20 +34,29 @@ func TestNetworksRegistry(t *testing.T) {
         t.Errorf("Expected 1 network, got %d", len(registry.Networks))
     }
 
-    if registry.Version != "0.6.0" {
-        t.Errorf("Expected version 0.6.0, got %s", registry.Version)
+    if registry.Version != "0.7.0" {
+        t.Errorf("Expected version 0.7.0, got %s", registry.Version)
     }
 
-    // Test network lookup
-    if network := registry.GetNetworkById("mainnet"); network == nil {
-        t.Error("Expected to find mainnet network")
+    // Test network lookup with new unified method
+    if network := registry.GetNetworkByGraphId("mainnet"); network == nil {
+        t.Error("Expected to find mainnet network by ID")
     }
 
-    if network := registry.GetNetworkByAlias("eth"); network == nil {
+    if network := registry.GetNetworkByGraphId("eth"); network == nil {
         t.Error("Expected to find network by alias 'eth'")
     }
 
-    if network := registry.GetNetworkById("nonexistent"); network != nil {
+    if network := registry.GetNetworkByGraphId("nonexistent"); network != nil {
         t.Error("Expected nil for nonexistent network")
+    }
+
+    // Test deprecated methods for backward compatibility
+    if network := registry.GetNetworkById("mainnet"); network == nil {
+        t.Error("Expected to find mainnet network with deprecated GetNetworkById")
+    }
+
+    if network := registry.GetNetworkByAlias("eth"); network == nil {
+        t.Error("Expected to find network with deprecated GetNetworkByAlias")
     }
 }

--- a/packages/golang/lib/client_test.go
+++ b/packages/golang/lib/client_test.go
@@ -59,4 +59,24 @@ func TestNetworksRegistry(t *testing.T) {
     if network := registry.GetNetworkByAlias("eth"); network == nil {
         t.Error("Expected to find network with deprecated GetNetworkByAlias")
     }
+
+    // Test CAIP-2 ID lookup
+    if network := registry.GetNetworkByCaip2Id("eip155:1"); network == nil {
+        t.Error("Expected to find network by CAIP-2 ID 'eip155:1'")
+    }
+
+    if network := registry.GetNetworkByCaip2Id("eip155:1"); network != nil {
+        if network.ID != "mainnet" {
+            t.Errorf("Expected network ID 'mainnet', got '%s'", network.ID)
+        }
+    }
+
+    if network := registry.GetNetworkByCaip2Id("nonexistent:id"); network != nil {
+        t.Error("Expected nil for nonexistent CAIP-2 ID")
+    }
+
+    // Test format validation - this test doesn't fail the test but should print a warning
+    if network := registry.GetNetworkByCaip2Id("invalid-format"); network != nil {
+        t.Error("Expected nil for invalid CAIP-2 ID format")
+    }
 }

--- a/packages/golang/lib/types.go
+++ b/packages/golang/lib/types.go
@@ -1,4 +1,4 @@
-// This file was generated from JSON Schema using quicktype, do not modify it directly.
+// Code generated from JSON Schema using quicktype. DO NOT EDIT.
 // To parse and unparse this JSON data, add this code to your project and do:
 //
 //    networksRegistry, err := UnmarshalNetworksRegistry(bytes)
@@ -50,8 +50,6 @@ type Network struct {
 	Firehose                                                                                  *Firehose        `json:"firehose,omitempty"`
 	// Display name of the network, e.g. Ethereum Mainnet, Bitcoin Testnet                                     
 	FullName                                                                                  string           `json:"fullName"`
-	// Genesis block information                                                                               
-	Genesis                                                                                   *Genesis         `json:"genesis,omitempty"`
 	// Graph Node specific configuration information                                                           
 	GraphNode                                                                                 *GraphNode       `json:"graphNode,omitempty"`
 	// Icons for the network                                                                                   
@@ -78,6 +76,8 @@ type Network struct {
 	Services                                                                                  Services         `json:"services"`
 	// Short display name of the network, e.g. Ethereum, BNB                                                   
 	ShortName                                                                                 string           `json:"shortName"`
+	// Token API specific configuration information                                                            
+	TokenAPI                                                                                  *TokenAPI        `json:"tokenApi,omitempty"`
 }
 
 type APIURL struct {
@@ -88,28 +88,36 @@ type APIURL struct {
 
 // Firehose block information
 type Firehose struct {
-	// Block type, e.g. sf.ethereum.type.v2.Block                                                             
-	BlockType                                                                                   string        `json:"blockType"`
-	// Protobuf definitions on buf.build, e.g. https://buf.build/streamingfast/firehose-ethereum              
-	BufURL                                                                                      string        `json:"bufUrl"`
-	// Bytes encoding, e.g. hex, 0xhex, base58                                                                
-	BytesEncoding                                                                               BytesEncoding `json:"bytesEncoding"`
-	// [optional] Whether there is support for extended EVM block model                                       
-	EvmExtendedModel                                                                            *bool         `json:"evmExtendedModel,omitempty"`
+	// Block features supported by the network                                                                        
+	BlockFeatures                                                                               []string              `json:"blockFeatures,omitempty"`
+	// Block type, e.g. sf.ethereum.type.v2.Block                                                                     
+	BlockType                                                                                   string                `json:"blockType"`
+	// Protobuf definitions on buf.build, e.g. https://buf.build/streamingfast/firehose-ethereum                      
+	BufURL                                                                                      string                `json:"bufUrl"`
+	// Bytes encoding, e.g. hex, 0xhex, base58                                                                        
+	BytesEncoding                                                                               BytesEncoding         `json:"bytesEncoding"`
+	// [optional] Timestamp when the network was deprecated in Firehose software                                      
+	DeprecatedAt                                                                                *time.Time            `json:"deprecatedAt,omitempty"`
+	// [optional] Whether there is support for extended EVM block model                                               
+	EvmExtendedModel                                                                            *bool                 `json:"evmExtendedModel,omitempty"`
+	// First available block information                                                                              
+	FirstStreamableBlock                                                                        *FirstStreamableBlock `json:"firstStreamableBlock,omitempty"`
 }
 
-// Genesis block information
-type Genesis struct {
-	// Hash of the genesis block either in 0x-prefixed hex or base58       
-	Hash                                                            string `json:"hash"`
-	// Block height of the genesis or the first available block            
-	Height                                                          int64  `json:"height"`
+// First available block information
+type FirstStreamableBlock struct {
+	// Block height of the first streamable block. Can be different from genesis       
+	Height                                                                      int64  `json:"height"`
+	// Id of the first streamable block either in 0x-prefixed hex or base58            
+	ID                                                                          string `json:"id"`
 }
 
 // Graph Node specific configuration information
 type GraphNode struct {
-	// [optional] Protocol name in graph-node, e.g. ethereum, near, arweave          
-	Protocol                                                               *Protocol `json:"protocol,omitempty"`
+	// [optional] Timestamp when the network was deprecated in Graph Node software           
+	DeprecatedAt                                                                  *time.Time `json:"deprecatedAt,omitempty"`
+	// [optional] Protocol name in graph-node, e.g. ethereum, near, arweave                  
+	Protocol                                                                      *Protocol  `json:"protocol,omitempty"`
 }
 
 // Icons for the network
@@ -150,6 +158,17 @@ type Services struct {
 	Subgraphs                                                                                 []string `json:"subgraphs,omitempty"`
 	// Substreams gRPC URLs, e.g. eth.substreams.pinax.network:443                                     
 	Substreams                                                                                []string `json:"substreams,omitempty"`
+	// Token API URLs, e.g. https://token-api.thegraph.com                                             
+	TokenAPI                                                                                  []string `json:"tokenApi,omitempty"`
+}
+
+// Token API specific configuration information
+type TokenAPI struct {
+	// [optional] Timestamp when the network was deprecated in Token API software           
+	DeprecatedAt                                                                 *time.Time `json:"deprecatedAt,omitempty"`
+	Features                                                                     []Feature  `json:"features,omitempty"`
+	// Network ID in Token API, has to be an ID or alias of an existing network             
+	NetworkID                                                                    *string    `json:"networkId,omitempty"`
 }
 
 // Kind of API
@@ -190,6 +209,7 @@ const (
 type NetworkType string
 
 const (
+	Beacon  NetworkType = "beacon"
 	Devnet  NetworkType = "devnet"
 	Mainnet NetworkType = "mainnet"
 	Testnet NetworkType = "testnet"
@@ -205,5 +225,16 @@ const (
 	ForkedFrom  RelationKind = "forkedFrom"
 	L2Of        RelationKind = "l2Of"
 	ShardOf     RelationKind = "shardOf"
+	SvmOf       RelationKind = "svmOf"
 	TestnetOf   RelationKind = "testnetOf"
+)
+
+// List of Token API features supported
+type Feature string
+
+const (
+	Dexes        Feature = "dexes"
+	FeatureOther Feature = "other"
+	Nfts         Feature = "nfts"
+	Tokens       Feature = "tokens"
 )

--- a/packages/golang/lib/version.go
+++ b/packages/golang/lib/version.go
@@ -1,2 +1,2 @@
 package registry
-const Version = "0.6.3"
+const Version = "0.7.0"

--- a/packages/rust/Cargo.toml
+++ b/packages/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-networks-registry"
-version = "0.6.3"
+version = "0.7.0"
 edition = "2021"
 description = "The Graph Networks Registry types and helpers"
 license = "MIT"

--- a/packages/rust/README.md
+++ b/packages/rust/README.md
@@ -33,6 +33,12 @@ fn main() {
     if let Some(network) = registry.get_network_by_graph_id("eth") {
         println!("Found ethereum by alias: {:?}", network);
     }
+
+    // Find network by CAIP-2 chain ID
+    if let Some(network) = registry.get_network_by_caip2_id("eip155:1") {
+        println!("Found ethereum by CAIP-2 ID: {:?}", network);
+        println!("ID: {}, CAIP-2 ID: {}", network.id, network.caip2_id);
+    }
 }
 
 ```

--- a/packages/rust/README.md
+++ b/packages/rust/README.md
@@ -11,7 +11,7 @@ If you want to always get up-to-date registry, make sure to use the latest versi
 `Cargo.toml`:
 ```toml
 [dependencies]
-graph-networks-registry = "0.6.1"
+graph-networks-registry = "0.7.0"
 ```
 
 ### Reading from a local file
@@ -22,11 +22,16 @@ To read the registry from a local file
 use graph_networks_registry::NetworksRegistry;
 fn main() {
     // Parse registry from JSON file
-    let registry = NetworksRegistry::from_file("TheGraphNetworksRegistry_v0_6_0.json")
+    let registry = NetworksRegistry::from_file("TheGraphNetworksRegistry_v0_7_0.json")
         .expect("Failed to parse registry");
 
-    if let Some(network) = registry.get_network_by_id("mainnet") {
+    if let Some(network) = registry.get_network_by_graph_id("mainnet") {
         println!("Found mainnet: {:?}", network);
+    }
+
+    // You can also use an alias with get_network_by_graph_id
+    if let Some(network) = registry.get_network_by_graph_id("eth") {
+        println!("Found ethereum by alias: {:?}", network);
     }
 }
 
@@ -58,5 +63,5 @@ If you don't need to fetch the registry from the network, you can turn off the `
 
 ```toml
 [dependencies]
-graph-networks-registry = { version = "0.6.1", default-features = false }
+graph-networks-registry = { version = "0.7.0", default-features = false }
 ```

--- a/packages/rust/examples/fetch/src/main.rs
+++ b/packages/rust/examples/fetch/src/main.rs
@@ -8,10 +8,17 @@ async fn main() {
 
     println!("Successfully loaded {} networks", registry.networks.len());
 
-    let network = registry.get_network_by_id("mainnet");
-    println!("Found mainnet by id: {}", network.expect("Failed to find mainnet").full_name);
+    // Using new get_network_by_graph_id method which handles both id and alias lookups
+    let network = registry.get_network_by_graph_id("mainnet");
+    println!(
+        "Querying registry for \"mainnet\" graph id: {}",
+        network.expect("Failed to find mainnet").full_name
+    );
 
-    // by alias
-    let network = registry.get_network_by_alias("ethereum");
-    println!("Found ethereum by alias: {}", network.expect("Failed to find ethereum").full_name);
+    // Using get_network_by_graph_id with an alias
+    let network = registry.get_network_by_graph_id("ethereum");
+    println!(
+        "Querying registry for \"ethereum\" graph id: {}",
+        network.expect("Failed to find ethereum").full_name
+    );
 }

--- a/packages/rust/examples/local/src/main.rs
+++ b/packages/rust/examples/local/src/main.rs
@@ -6,10 +6,17 @@ fn main() {
 
     println!("Successfully loaded {} networks", registry.networks.len());
 
-    let network = registry.get_network_by_id("mainnet");
-    println!("Found mainnet by id: {}", network.expect("Failed to find mainnet").full_name);
+    // Using new get_network_by_graph_id method which handles both id and alias lookups
+    let network = registry.get_network_by_graph_id("mainnet");
+    println!(
+        "Querying registry for \"mainnet\" graph id: {}",
+        network.expect("Failed to find mainnet").full_name
+    );
 
-    // by alias
-    let network = registry.get_network_by_alias("ethereum");
-    println!("Found ethereum by alias: {}", network.expect("Failed to find ethereum").full_name);
+    // Using get_network_by_graph_id with an alias
+    let network = registry.get_network_by_graph_id("ethereum");
+    println!(
+        "Querying registry for \"ethereum\" graph id: {}",
+        network.expect("Failed to find ethereum").full_name
+    );
 }

--- a/packages/rust/src/client.rs
+++ b/packages/rust/src/client.rs
@@ -87,6 +87,11 @@ impl NetworksRegistry {
     /// # Returns
     ///
     /// Returns `Some(&Network)` if found, `None` otherwise
+    ///
+    /// # Deprecated
+    ///
+    /// This function is deprecated. Use `get_network_by_graph_id` instead.
+    #[deprecated(since = "0.7.0", note = "Use get_network_by_graph_id instead")]
     pub fn get_network_by_id<'a>(&'a self, id: &str) -> Option<&'a Network> {
         self.networks.iter().find(|network| network.id == id)
     }
@@ -100,6 +105,11 @@ impl NetworksRegistry {
     /// # Returns
     ///
     /// Returns `Some(&Network)` if found, `None` otherwise
+    ///
+    /// # Deprecated
+    ///
+    /// This function is deprecated. Use `get_network_by_graph_id` instead.
+    #[deprecated(since = "0.7.0", note = "Use get_network_by_graph_id instead")]
     pub fn get_network_by_alias<'a>(&'a self, alias: &str) -> Option<&'a Network> {
         self.networks.iter().find(|network| {
             network
@@ -107,6 +117,21 @@ impl NetworksRegistry {
                 .as_ref()
                 .map_or(false, |aliases| aliases.contains(&alias.to_string()))
         })
+    }
+
+    /// Looks up a network by its graph id (either its id field or one of its aliases)
+    ///
+    /// # Arguments
+    ///
+    /// * `id` - A graph id, which could be either the network's id or one of its aliases
+    ///
+    /// # Returns
+    ///
+    /// Returns `Some(&Network)` if found, `None` otherwise
+    pub fn get_network_by_graph_id<'a>(&'a self, id: &str) -> Option<&'a Network> {
+        self.networks
+            .iter()
+            .find(|network| network.id == id || network.aliases.as_ref().map_or(false, |aliases| aliases.contains(&id.to_string())))
     }
 
     #[cfg(feature = "fetch")]
@@ -175,6 +200,17 @@ mod tests {
         let network = registry.get_network_by_id("mainnet");
         assert!(network.is_some());
         assert_eq!(network.unwrap().id, "mainnet");
+
+        let network = registry.get_network_by_graph_id("mainnet");
+        assert!(network.is_some());
+        assert_eq!(network.unwrap().id, "mainnet");
+
+        let network = registry.get_network_by_graph_id("eth");
+        assert!(network.is_some());
+        assert_eq!(network.unwrap().id, "mainnet");
+
+        let network = registry.get_network_by_graph_id("nonexistent");
+        assert!(network.is_none());
     }
 
     #[cfg(feature = "fetch")]
@@ -213,7 +249,7 @@ mod tests {
             let result = NetworksRegistry::from_latest_version().await;
             assert!(result.is_ok(), "Should succeed with primary URL");
             let registry = result.unwrap();
-            assert!(registry.get_network_by_id("mainnet").is_some());
+            assert!(registry.get_network_by_graph_id("mainnet").is_some());
             primary_mock.assert();
             fallback_mock.assert();
 
@@ -234,7 +270,7 @@ mod tests {
             let result = NetworksRegistry::from_latest_version().await;
             assert!(result.is_ok(), "Should succeed using fallback URL");
             let registry = result.unwrap();
-            assert!(registry.get_network_by_id("mainnet").is_some());
+            assert!(registry.get_network_by_graph_id("mainnet").is_some());
             primary_mock.assert();
             fallback_mock.assert();
 

--- a/packages/rust/src/client.rs
+++ b/packages/rust/src/client.rs
@@ -36,7 +36,7 @@ impl NetworksRegistry {
     ///
     /// Returns an error if the JSON is invalid or doesn't match the expected format
     pub fn from_json(json: &str) -> Result<Self, Error> {
-        Ok(json.parse()?)
+        json.parse()
     }
 
     /// Creates a new NetworksRegistry by reading from a file
@@ -146,17 +146,12 @@ impl NetworksRegistry {
     /// ```
     pub fn get_network_by_caip2_id<'a>(&'a self, chain_id: &str) -> Option<&'a Network> {
         // Check if the chain_id is in the correct format (contains a colon)
-        if !chain_id.contains(":") {
+        if !chain_id.contains(':') {
             eprintln!("Warning: CAIP-2 Chain ID should be in the format '[namespace]:[reference]', e.g., 'eip155:1'");
             return None;
         }
 
-        for network in &self.networks {
-            if network.caip2_id == chain_id {
-                return Some(network);
-            }
-        }
-        None
+        self.networks.iter().find(|&network| network.caip2_id == chain_id)
     }
 
     #[cfg(feature = "fetch")]
@@ -166,11 +161,11 @@ impl NetworksRegistry {
             return Err(Error::Http(response.error_for_status().unwrap_err()));
         }
         let text = response.text().await?;
-        Ok(Self::from_json(&text)?)
+        Self::from_json(&text)
     }
 
     #[cfg(feature = "fetch")]
-    async fn from_version<'a>(version: RegistryVersion<'a>) -> Result<Self, Error> {
+    async fn from_version(version: RegistryVersion<'_>) -> Result<Self, Error> {
         match Self::fetch_registry(&version.get_primary_url()).await {
             Ok(registry) => Ok(registry),
             Err(primary_err) => {

--- a/packages/rust/src/client.rs
+++ b/packages/rust/src/client.rs
@@ -134,6 +134,31 @@ impl NetworksRegistry {
             .find(|network| network.id == id || network.aliases.as_ref().map_or(false, |aliases| aliases.contains(&id.to_string())))
     }
 
+    /// Looks up a network by its CAIP-2 chain ID
+    ///
+    /// # Arguments
+    ///
+    /// * `chain_id` - The CAIP-2 chain ID in the format "[namespace]:[reference]" (e.g., "eip155:1")
+    ///
+    /// # Returns
+    ///
+    /// Returns `Some(&Network)` if found, `None` otherwise
+    /// ```
+    pub fn get_network_by_caip2_id<'a>(&'a self, chain_id: &str) -> Option<&'a Network> {
+        // Check if the chain_id is in the correct format (contains a colon)
+        if !chain_id.contains(":") {
+            eprintln!("Warning: CAIP-2 Chain ID should be in the format '[namespace]:[reference]', e.g., 'eip155:1'");
+            return None;
+        }
+
+        for network in &self.networks {
+            if network.caip2_id == chain_id {
+                return Some(network);
+            }
+        }
+        None
+    }
+
     #[cfg(feature = "fetch")]
     async fn fetch_registry(url: &str) -> Result<Self, Error> {
         let response = reqwest::get(url).await?;

--- a/packages/rust/src/types.rs
+++ b/packages/rust/src/types.rs
@@ -60,9 +60,6 @@ pub struct Network {
     /// Display name of the network, e.g. Ethereum Mainnet, Bitcoin Testnet
     pub full_name: String,
 
-    /// Genesis block information
-    pub genesis: Option<Genesis>,
-
     /// Graph Node specific configuration information
     pub graph_node: Option<GraphNode>,
 
@@ -100,6 +97,9 @@ pub struct Network {
 
     /// Short display name of the network, e.g. Ethereum, BNB
     pub short_name: String,
+
+    /// Token API specific configuration information
+    pub token_api: Option<TokenApi>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -129,6 +129,9 @@ pub enum ApiUrlKind {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Firehose {
+    /// Block features supported by the network
+    pub block_features: Option<Vec<String>>,
+
     /// Block type, e.g. sf.ethereum.type.v2.Block
     pub block_type: String,
 
@@ -138,8 +141,14 @@ pub struct Firehose {
     /// Bytes encoding, e.g. hex, 0xhex, base58
     pub bytes_encoding: BytesEncoding,
 
+    /// [optional] Timestamp when the network was deprecated in Firehose software
+    pub deprecated_at: Option<String>,
+
     /// [optional] Whether there is support for extended EVM block model
     pub evm_extended_model: Option<bool>,
+
+    /// First available block information
+    pub first_streamable_block: Option<FirstStreamableBlock>,
 }
 
 /// Bytes encoding, e.g. hex, 0xhex, base58
@@ -158,19 +167,23 @@ pub enum BytesEncoding {
     The0Xhex,
 }
 
-/// Genesis block information
+/// First available block information
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Genesis {
-    /// Hash of the genesis block either in 0x-prefixed hex or base58
-    pub hash: String,
-
-    /// Block height of the genesis or the first available block
+pub struct FirstStreamableBlock {
+    /// Block height of the first streamable block. Can be different from genesis
     pub height: i64,
+
+    /// Id of the first streamable block either in 0x-prefixed hex or base58
+    pub id: String,
 }
 
 /// Graph Node specific configuration information
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct GraphNode {
+    /// [optional] Timestamp when the network was deprecated in Graph Node software
+    pub deprecated_at: Option<String>,
+
     /// [optional] Protocol name in graph-node, e.g. ethereum, near, arweave
     pub protocol: Option<Protocol>,
 }
@@ -223,6 +236,8 @@ pub struct IndexerDocsUrl {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum NetworkType {
+    Beacon,
+
     Devnet,
 
     Mainnet,
@@ -260,12 +275,16 @@ pub enum RelationKind {
     #[serde(rename = "shardOf")]
     ShardOf,
 
+    #[serde(rename = "svmOf")]
+    SvmOf,
+
     #[serde(rename = "testnetOf")]
     TestnetOf,
 }
 
 /// Services available for the network in the ecosystem
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Services {
     /// Firehose gRPC URLs, e.g. eth.firehose.pinax.network:443
     pub firehose: Option<Vec<String>>,
@@ -278,4 +297,33 @@ pub struct Services {
 
     /// Substreams gRPC URLs, e.g. eth.substreams.pinax.network:443
     pub substreams: Option<Vec<String>>,
+
+    /// Token API URLs, e.g. https://token-api.thegraph.com
+    pub token_api: Option<Vec<String>>,
+}
+
+/// Token API specific configuration information
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TokenApi {
+    /// [optional] Timestamp when the network was deprecated in Token API software
+    pub deprecated_at: Option<String>,
+
+    pub features: Option<Vec<Feature>>,
+
+    /// Network ID in Token API, has to be an ID or alias of an existing network
+    pub network_id: Option<String>,
+}
+
+/// List of Token API features supported
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Feature {
+    Dexes,
+
+    Nfts,
+
+    Other,
+
+    Tokens,
 }

--- a/packages/rust/src/types.rs
+++ b/packages/rust/src/types.rs
@@ -11,7 +11,7 @@
 //     let model: NetworksRegistry = serde_json::from_str(&json).unwrap();
 // }
 
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/packages/typescript/README.md
+++ b/packages/typescript/README.md
@@ -52,6 +52,17 @@ if (ethereum) {
     console.log(ethereum.fullName); // "Ethereum Mainnet"
 }
 
+// Find network by CAIP-2 chain ID
+const ethereumByChainId = registry.getNetworkByCaip2Id('eip155:1');
+if (ethereumByChainId) {
+    console.log(ethereumByChainId.fullName); // "Ethereum Mainnet"
+    console.log(ethereumByChainId.id); // "mainnet"
+}
+
+// Invalid format will produce a warning and return undefined
+const invalidNetwork = registry.getNetworkByCaip2Id('invalid-format');
+// Warning: CAIP-2 Chain ID should be in the format '[namespace]:[reference]', e.g., 'eip155:1'
+
 // Deprecated methods (will be removed in future versions)
 // Find network by ID
 // @deprecated Use getNetworkByGraphId instead

--- a/packages/typescript/README.md
+++ b/packages/typescript/README.md
@@ -23,8 +23,8 @@ import { NetworksRegistry } from '@pinax/graph-networks-registry';
 const registry = await NetworksRegistry.fromLatestVersion();
 
 // Load from specific version tag at networks-registry.thegraph.com
-const registry = await NetworksRegistry.fromExactVersion('0.6.0');
-const registry = await NetworksRegistry.fromExactVersion('0.6.x');
+const registry = await NetworksRegistry.fromExactVersion('0.7.0');
+const registry = await NetworksRegistry.fromExactVersion('0.7.x');
 
 // Load from URL
 const registry = await NetworksRegistry.fromUrl('https://networks-registry.thegraph.com/TheGraphNetworksRegistry.json');
@@ -39,15 +39,25 @@ const registry = NetworksRegistry.fromJson(jsonString);
 ### Working with Networks
 
 ```typescript
-// Find network by ID
-const mainnet = registry.getNetworkById('mainnet');
+// Find network by graph ID (works with both network ID and alias)
+const mainnet = registry.getNetworkByGraphId('mainnet');
 if (mainnet) {
     console.log(mainnet.fullName); // "Ethereum Mainnet"
     console.log(mainnet.caip2Id); // "eip155:1"
 }
-// Find network by alias
-const mainnet = registry.getNetworkByAlias('eth');
-if (mainnet) {
-    console.log(mainnet.fullName); // "Ethereum Mainnet"
+
+// You can also use an alias with getNetworkByGraphId
+const ethereum = registry.getNetworkByGraphId('eth');
+if (ethereum) {
+    console.log(ethereum.fullName); // "Ethereum Mainnet"
 }
+
+// Deprecated methods (will be removed in future versions)
+// Find network by ID
+// @deprecated Use getNetworkByGraphId instead
+const mainnetById = registry.getNetworkById('mainnet');
+
+// Find network by alias
+// @deprecated Use getNetworkByGraphId instead
+const mainnetByAlias = registry.getNetworkByAlias('eth');
 ```

--- a/packages/typescript/eslint.config.js
+++ b/packages/typescript/eslint.config.js
@@ -1,0 +1,67 @@
+import eslint from '@eslint/js';
+import tseslint from '@typescript-eslint/eslint-plugin';
+import tseslintParser from '@typescript-eslint/parser';
+import globals from 'globals';
+
+export default [
+  eslint.configs.recommended,
+  {
+    // Base configuration for all TS files
+    files: ['**/*.ts'],
+    languageOptions: {
+      parser: tseslintParser,
+      parserOptions: {
+        ecmaVersion: 'latest',
+        sourceType: 'module',
+      },
+      globals: {
+        ...globals.node,
+      },
+    },
+    plugins: {
+      '@typescript-eslint': tseslint,
+    },
+    rules: {
+      'no-console': 'off',
+      'no-prototype-builtins': 'off',
+      'no-undef': 'off', // TypeScript handles this better
+      'no-empty': 'warn',
+      'no-unused-vars': 'off', // Using TypeScript's version instead
+      '@typescript-eslint/no-unused-vars': ['warn', { 
+        argsIgnorePattern: '^_',
+        varsIgnorePattern: '^_',
+      }],
+      '@typescript-eslint/explicit-module-boundary-types': 'off',
+    },
+  },
+  {
+    // Special configuration for test files
+    files: ['**/__tests__/**/*.ts', '**/*.test.ts'],
+    languageOptions: {
+      globals: {
+        ...globals.node,
+        ...globals.jest,
+        describe: 'readonly',
+        test: 'readonly',
+        expect: 'readonly',
+        beforeEach: 'readonly',
+        afterEach: 'readonly',
+        jest: 'readonly',
+        NodeJS: 'readonly',
+      },
+    },
+    rules: {
+      '@typescript-eslint/no-unused-vars': 'off',
+      'no-undef': 'off',
+    },
+  },
+  {
+    // Special configuration for generated types
+    files: ['**/types.ts'],
+    rules: {
+      'no-unused-vars': 'off',
+      '@typescript-eslint/no-unused-vars': 'off',
+      'no-empty': 'off',
+    },
+  },
+];

--- a/packages/typescript/examples/fetch/index.ts
+++ b/packages/typescript/examples/fetch/index.ts
@@ -8,9 +8,10 @@ async function main() {
 
   console.log("Successfully loaded", registry.networks.length, "networks");
 
-  const mainnet = registry.getNetworkById("mainnet");
+  // Using the new getNetworkByGraphId method which works with both network ID and alias
+  const mainnet = registry.getNetworkByGraphId("mainnet");
   if (mainnet) {
-    console.log("Found mainnet:", mainnet.fullName);
+    console.log("Found mainnet by graph ID:", mainnet.fullName);
   }
 
   const apis = registry.getApiUrls("mainnet");

--- a/packages/typescript/examples/local/index.ts
+++ b/packages/typescript/examples/local/index.ts
@@ -5,14 +5,14 @@ const registry = NetworksRegistry.fromFile("../../../../sample/TheGraphNetworksR
 
 console.log("Successfully loaded", registry.networks.length, "networks");
 
-// Get network by ID
-const mainnet = registry.getNetworkById("mainnet");
+// Get network by graph ID (works with both network ID and alias)
+const mainnet = registry.getNetworkByGraphId("mainnet");
 if (mainnet) {
-  console.log("Found mainnet:", mainnet.fullName);
+  console.log("Found mainnet by graph ID:", mainnet.fullName);
 }
 
-// Get network by alias
-const ethereum = registry.getNetworkByAlias("eth");
+// Get network by graph ID using an alias
+const ethereum = registry.getNetworkByGraphId("eth");
 if (ethereum) {
-  console.log("Found ethereum by alias:", ethereum.fullName);
+  console.log("Found ethereum by graph ID:", ethereum.fullName);
 }

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinax/graph-networks-registry",
-  "version": "0.6.7",
+  "version": "0.7.0",
   "description": "TypeScript types and helpers for The Graph Networks Registry",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -13,6 +13,7 @@
     "build": "tsc",
     "clean": "rm -rf dist",
     "test": "bun test",
+    "lint": "eslint src --ext .ts",
     "docs": "typedoc --out docs src",
     "prepublishOnly": "bun run clean && bun run build"
   },
@@ -39,8 +40,12 @@
     "access": "public"
   },
   "devDependencies": {
+    "@eslint/js": "^9.30.1",
     "@types/jest": "^29.5.14",
+    "@typescript-eslint/eslint-plugin": "^8.35.1",
+    "@typescript-eslint/parser": "^8.35.1",
     "bun-types": "1",
+    "eslint": "^9.30.1",
     "typedoc": "^0.26.11",
     "typescript": "^5.0.0"
   }

--- a/packages/typescript/src/__tests__/client.test.ts
+++ b/packages/typescript/src/__tests__/client.test.ts
@@ -6,8 +6,8 @@ import { APIURLKind } from "../types";
 
 describe("NetworksRegistry", () => {
   const testRegistryJson = {
-    $schema: "https://networks-registry.thegraph.com/TheGraphNetworksRegistrySchema_v0_6.json",
-    version: "0.6.0",
+    $schema: "https://networks-registry.thegraph.com/TheGraphNetworksRegistrySchema_v0_7.json",
+    version: "0.7.0",
     title: "Test Registry",
     description: "Test Registry",
     updatedAt: "2025-01-01T00:00:00Z",
@@ -53,7 +53,7 @@ describe("NetworksRegistry", () => {
     test("should parse registry from JSON string", () => {
       const registry = NetworksRegistry.fromJson(JSON.stringify(testRegistryJson));
       expect(registry.networks.length).toBe(1);
-      expect(registry.version).toBe("0.6.0");
+      expect(registry.version).toBe("0.7.0");
     });
 
     test("should load registry from file", () => {
@@ -87,6 +87,26 @@ describe("NetworksRegistry", () => {
       const network2 = registry.getNetworkByAlias("ethereum");
       expect(network2).toBeDefined();
       expect(network2?.id).toBe("mainnet");
+    });
+
+    test("should find network by graph ID", () => {
+      // Find by network ID
+      const network = registry.getNetworkByGraphId("mainnet");
+      expect(network).toBeDefined();
+      expect(network?.id).toBe("mainnet");
+
+      // Find by alias
+      const network2 = registry.getNetworkByGraphId("eth");
+      expect(network2).toBeDefined();
+      expect(network2?.id).toBe("mainnet");
+
+      const network3 = registry.getNetworkByGraphId("ethereum");
+      expect(network3).toBeDefined();
+      expect(network3?.id).toBe("mainnet");
+
+      // Non-existent ID
+      const network4 = registry.getNetworkByGraphId("nonexistent");
+      expect(network4).toBeUndefined();
     });
 
     test("should return undefined for nonexistent network", () => {

--- a/packages/typescript/src/__tests__/client.test.ts
+++ b/packages/typescript/src/__tests__/client.test.ts
@@ -116,6 +116,33 @@ describe("NetworksRegistry", () => {
       const network2 = registry.getNetworkByAlias("nonexistent");
       expect(network2).toBeUndefined();
     });
+
+    test("should find network by CAIP-2 chain ID", () => {
+      const network = registry.getNetworkByCaip2Id("eip155:1");
+      expect(network).toBeDefined();
+      expect(network?.id).toBe("mainnet");
+    });
+
+    test("should return undefined for nonexistent CAIP-2 chain ID", () => {
+      const network = registry.getNetworkByCaip2Id("cosmos:cosmoshub-4");
+      expect(network).toBeUndefined();
+    });
+
+    test("should warn and return undefined for invalid CAIP-2 chain ID format", () => {
+      // Mock console.warn
+      const originalConsoleWarn = console.warn;
+      const mockConsoleWarn = jest.fn();
+      console.warn = mockConsoleWarn;
+
+      const network = registry.getNetworkByCaip2Id("invalid-format");
+      expect(network).toBeUndefined();
+      expect(mockConsoleWarn).toHaveBeenCalledWith(
+        "Warning: CAIP-2 Chain ID should be in the format '[namespace]:[reference]', e.g., 'eip155:1'"
+      );
+
+      // Restore console.warn
+      console.warn = originalConsoleWarn;
+    });
   });
 
   describe("version URLs", () => {

--- a/packages/typescript/src/client.ts
+++ b/packages/typescript/src/client.ts
@@ -10,7 +10,9 @@ try {
   // Only import fs in Node.js environment
   const fs = require("fs");
   readFileSync = fs.readFileSync;
-} catch {}
+} catch {
+  // Ignore error - fs is not available in browser environments
+}
 
 /**
  * Client for interacting with The Graph Networks Registry.

--- a/packages/typescript/src/client.ts
+++ b/packages/typescript/src/client.ts
@@ -245,6 +245,26 @@ export class NetworksRegistry {
   }
 
   /**
+   * Finds a network by its CAIP-2 chain ID.
+   *
+   * @param chainId - The CAIP-2 chain ID in the format "[namespace]:[reference]" (e.g., "eip155:1")
+   * @returns The network if found, undefined otherwise
+   *
+   * @example
+   * ```typescript
+   * const ethereum = registry.getNetworkByCaip2Id("eip155:1");
+   * ```
+   */
+  getNetworkByCaip2Id(chainId: string): Network | undefined {
+    if (!chainId.includes(":")) {
+      console.warn("Warning: CAIP-2 Chain ID should be in the format '[namespace]:[reference]', e.g., 'eip155:1'");
+      return undefined;
+    }
+
+    return this.registry.networks.find((network) => network.caip2Id === chainId);
+  }
+
+  /**
    * Gets API URLs for a network, filtered by kind and with environment variables applied.
    * Environment variable placeholders in the format {VARIABLE_NAME} will be replaced with
    * actual environment variable values. URLs that reference non-existent environment

--- a/packages/typescript/src/client.ts
+++ b/packages/typescript/src/client.ts
@@ -201,6 +201,7 @@ export class NetworksRegistry {
    *
    * @param id - The network ID (e.g. "mainnet", "optimism")
    * @returns The network if found, undefined otherwise
+   * @deprecated Use getNetworkByGraphId instead
    *
    * @example
    * ```typescript
@@ -216,6 +217,7 @@ export class NetworksRegistry {
    *
    * @param alias - The network ID or alias (e.g. "eth" for Ethereum mainnet)
    * @returns The network if found, undefined otherwise
+   * @deprecated Use getNetworkByGraphId instead
    *
    * @example
    * ```typescript
@@ -224,6 +226,22 @@ export class NetworksRegistry {
    */
   getNetworkByAlias(alias: string): Network | undefined {
     return this.registry.networks.find((network) => network.id === alias || network.aliases?.includes(alias));
+  }
+
+  /**
+   * Finds a network by its graph ID (either its ID field or one of its aliases).
+   *
+   * @param id - The graph ID, which could be either the network's ID or one of its aliases
+   * @returns The network if found, undefined otherwise
+   *
+   * @example
+   * ```typescript
+   * const mainnet = registry.getNetworkByGraphId("mainnet");
+   * const ethereum = registry.getNetworkByGraphId("eth");
+   * ```
+   */
+  getNetworkByGraphId(id: string): Network | undefined {
+    return this.registry.networks.find((network) => network.id === id || network.aliases?.includes(id));
   }
 
   /**

--- a/packages/typescript/src/types.ts
+++ b/packages/typescript/src/types.ts
@@ -60,10 +60,6 @@ export interface Network {
      */
     fullName: string;
     /**
-     * Genesis block information
-     */
-    genesis?: Genesis;
-    /**
      * Graph Node specific configuration information
      */
     graphNode?: GraphNode;
@@ -113,6 +109,10 @@ export interface Network {
      * Short display name of the network, e.g. Ethereum, BNB
      */
     shortName: string;
+    /**
+     * Token API specific configuration information
+     */
+    tokenApi?: TokenAPI;
 }
 
 export interface APIURL {
@@ -139,6 +139,10 @@ export enum APIURLKind {
  */
 export interface Firehose {
     /**
+     * Block features supported by the network
+     */
+    blockFeatures?: string[];
+    /**
      * Block type, e.g. sf.ethereum.type.v2.Block
      */
     blockType: string;
@@ -151,9 +155,17 @@ export interface Firehose {
      */
     bytesEncoding: BytesEncoding;
     /**
+     * [optional] Timestamp when the network was deprecated in Firehose software
+     */
+    deprecatedAt?: Date;
+    /**
      * [optional] Whether there is support for extended EVM block model
      */
     evmExtendedModel?: boolean;
+    /**
+     * First available block information
+     */
+    firstStreamableBlock?: FirstStreamableBlock;
 }
 
 /**
@@ -168,23 +180,27 @@ export enum BytesEncoding {
 }
 
 /**
- * Genesis block information
+ * First available block information
  */
-export interface Genesis {
+export interface FirstStreamableBlock {
     /**
-     * Hash of the genesis block either in 0x-prefixed hex or base58
-     */
-    hash: string;
-    /**
-     * Block height of the genesis or the first available block
+     * Block height of the first streamable block. Can be different from genesis
      */
     height: number;
+    /**
+     * Id of the first streamable block either in 0x-prefixed hex or base58
+     */
+    id: string;
 }
 
 /**
  * Graph Node specific configuration information
  */
 export interface GraphNode {
+    /**
+     * [optional] Timestamp when the network was deprecated in Graph Node software
+     */
+    deprecatedAt?: Date;
     /**
      * [optional] Protocol name in graph-node, e.g. ethereum, near, arweave
      */
@@ -242,6 +258,7 @@ export interface IndexerDocsURL {
  * Whether the network is a mainnet/testnet/devnet
  */
 export enum NetworkType {
+    Beacon = "beacon",
     Devnet = "devnet",
     Mainnet = "mainnet",
     Testnet = "testnet",
@@ -268,6 +285,7 @@ export enum RelationKind {
     L2Of = "l2Of",
     Other = "other",
     ShardOf = "shardOf",
+    SvmOf = "svmOf",
     TestnetOf = "testnetOf",
 }
 
@@ -291,6 +309,35 @@ export interface Services {
      * Substreams gRPC URLs, e.g. eth.substreams.pinax.network:443
      */
     substreams?: string[];
+    /**
+     * Token API URLs, e.g. https://token-api.thegraph.com
+     */
+    tokenApi?: string[];
+}
+
+/**
+ * Token API specific configuration information
+ */
+export interface TokenAPI {
+    /**
+     * [optional] Timestamp when the network was deprecated in Token API software
+     */
+    deprecatedAt?: Date;
+    features?:     Feature[];
+    /**
+     * Network ID in Token API, has to be an ID or alias of an existing network
+     */
+    networkId?: string;
+}
+
+/**
+ * List of Token API features supported
+ */
+export enum Feature {
+    Dexes = "dexes",
+    Nfts = "nfts",
+    Other = "other",
+    Tokens = "tokens",
 }
 
 // Converts JSON strings to/from your types
@@ -474,7 +521,6 @@ const typeMap: any = {
         { json: "explorerUrls", js: "explorerUrls", typ: u(undefined, a("")) },
         { json: "firehose", js: "firehose", typ: u(undefined, r("Firehose")) },
         { json: "fullName", js: "fullName", typ: "" },
-        { json: "genesis", js: "genesis", typ: u(undefined, r("Genesis")) },
         { json: "graphNode", js: "graphNode", typ: u(undefined, r("GraphNode")) },
         { json: "icon", js: "icon", typ: u(undefined, r("Icon")) },
         { json: "id", js: "id", typ: "" },
@@ -487,22 +533,27 @@ const typeMap: any = {
         { json: "secondName", js: "secondName", typ: u(undefined, "") },
         { json: "services", js: "services", typ: r("Services") },
         { json: "shortName", js: "shortName", typ: "" },
+        { json: "tokenApi", js: "tokenApi", typ: u(undefined, r("TokenAPI")) },
     ], false),
     "APIURL": o([
         { json: "kind", js: "kind", typ: r("APIURLKind") },
         { json: "url", js: "url", typ: "" },
     ], false),
     "Firehose": o([
+        { json: "blockFeatures", js: "blockFeatures", typ: u(undefined, a("")) },
         { json: "blockType", js: "blockType", typ: "" },
         { json: "bufUrl", js: "bufUrl", typ: "" },
         { json: "bytesEncoding", js: "bytesEncoding", typ: r("BytesEncoding") },
+        { json: "deprecatedAt", js: "deprecatedAt", typ: u(undefined, Date) },
         { json: "evmExtendedModel", js: "evmExtendedModel", typ: u(undefined, true) },
+        { json: "firstStreamableBlock", js: "firstStreamableBlock", typ: u(undefined, r("FirstStreamableBlock")) },
     ], false),
-    "Genesis": o([
-        { json: "hash", js: "hash", typ: "" },
+    "FirstStreamableBlock": o([
         { json: "height", js: "height", typ: 0 },
+        { json: "id", js: "id", typ: "" },
     ], false),
     "GraphNode": o([
+        { json: "deprecatedAt", js: "deprecatedAt", typ: u(undefined, Date) },
         { json: "protocol", js: "protocol", typ: u(undefined, r("Protocol")) },
     ], false),
     "Icon": o([
@@ -525,6 +576,12 @@ const typeMap: any = {
         { json: "sps", js: "sps", typ: u(undefined, a("")) },
         { json: "subgraphs", js: "subgraphs", typ: u(undefined, a("")) },
         { json: "substreams", js: "substreams", typ: u(undefined, a("")) },
+        { json: "tokenApi", js: "tokenApi", typ: u(undefined, a("")) },
+    ], false),
+    "TokenAPI": o([
+        { json: "deprecatedAt", js: "deprecatedAt", typ: u(undefined, Date) },
+        { json: "features", js: "features", typ: u(undefined, a(r("Feature"))) },
+        { json: "networkId", js: "networkId", typ: u(undefined, "") },
     ], false),
     "APIURLKind": [
         "blockscout",
@@ -549,6 +606,7 @@ const typeMap: any = {
         "starknet",
     ],
     "NetworkType": [
+        "beacon",
         "devnet",
         "mainnet",
         "testnet",
@@ -560,6 +618,13 @@ const typeMap: any = {
         "l2Of",
         "other",
         "shardOf",
+        "svmOf",
         "testnetOf",
+    ],
+    "Feature": [
+        "dexes",
+        "nfts",
+        "other",
+        "tokens",
     ],
 };

--- a/packages/typescript/src/version.ts
+++ b/packages/typescript/src/version.ts
@@ -1,1 +1,1 @@
-export const schemaVersion = "0.6";
+export const schemaVersion = "0.7";

--- a/sample/TheGraphNetworksRegistry.json
+++ b/sample/TheGraphNetworksRegistry.json
@@ -1,9 +1,9 @@
 {
-  "$schema": "https://networks-registry.thegraph.com/NetworksRegistrySchema_v0_6.json",
-  "version": "0.6.0",
+  "$schema": "https://networks-registry.thegraph.com/TheGraphNetworksRegistrySchema_v0_7.json",
+  "version": "0.7.0",
   "title": "The Graph networks registry",
-  "description": "This registry was generated and validated. To add a chain, open a pull request: https://github.com/graphprotocol/networks-registry",
-  "updatedAt": "2024-11-18T22:33:02.385Z",
+  "description": "This registry was generated and validated at https://github.com/graphprotocol/networks-registry",
+  "updatedAt": "2025-07-02T19:53:42.517Z",
   "networks": [
     {
       "id": "mainnet",
@@ -23,29 +23,31 @@
         "https://etherscan.io"
       ],
       "rpcUrls": [
-        "https://rpc.ankr.com/eth",
-        "https://cloudflare-eth.com",
-        "https://eth.rpc.pinax.network/v1/{PINAX_API_KEY}",
+        "https://ethereum-rpc.publicnode.com",
+        "https://mainnet.gateway.tenderly.co",
+        "https://eth.rpc.service.pinax.network",
         "https://mainnet.infura.io/v3/{INFURA_API_KEY}"
       ],
       "apiUrls": [
         {
-          "url": "https://api.etherscan.io/api",
+          "url": "https://mainnet.abi.pinax.network/api",
           "kind": "etherscan"
         },
         {
           "url": "https://eth.blockscout.com/api",
           "kind": "blockscout"
+        },
+        {
+          "url": "https://api.routescan.io/v2/network/mainnet/evm/1/etherscan/api",
+          "kind": "etherscan"
         }
       ],
       "networkType": "mainnet",
       "services": {
         "subgraphs": [
-          "https://api.thegraph.com/deploy"
+          "https://api.studio.thegraph.com/deploy"
         ],
-        "sps": [
-          "https://api.thegraph.com/deploy"
-        ],
+        "sps": [],
         "firehose": [
           "eth.firehose.pinax.network:443",
           "mainnet.eth.streamingfast.io:443"
@@ -53,6 +55,9 @@
         "substreams": [
           "eth.substreams.pinax.network:443",
           "mainnet.eth.streamingfast.io:443"
+        ],
+        "tokenApi": [
+          "https://token-api.thegraph.com"
         ]
       },
       "issuanceRewards": true,
@@ -61,18 +66,29 @@
       "indexerDocsUrls": [
         {
           "url": "https://docs.infradao.com/archive-nodes-101/ethereum",
-          "description": "Arhchive Nodes 101"
+          "description": "Archive Nodes 101"
         }
       ],
-      "genesis": {
-        "hash": "0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3",
-        "height": 0
-      },
       "firehose": {
         "blockType": "sf.ethereum.type.v2.Block",
         "evmExtendedModel": true,
         "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
-        "bytesEncoding": "hex"
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3",
+          "height": 0
+        },
+        "blockFeatures": [
+          "extended"
+        ]
+      },
+      "tokenApi": {
+        "features": [
+          "tokens",
+          "dexes",
+          "nfts"
+        ],
+        "networkId": "mainnet"
       },
       "icon": {
         "web3Icons": {
@@ -86,7 +102,8 @@
       "fullName": "OP Mainnet",
       "aliases": [
         "evm-10",
-        "op-mainnet"
+        "op-mainnet",
+        "optimism-mainnet"
       ],
       "caip2Id": "eip155:10",
       "graphNode": {
@@ -104,28 +121,33 @@
       "rpcUrls": [
         "https://mainnet.optimism.io",
         "https://optimism-rpc.publicnode.com",
-        "https://optimism.rpc.pinax.network/v1/{PINAX_API_KEY}"
+        "https://optimism.rpc.service.pinax.network"
       ],
       "apiUrls": [
         {
           "url": "https://optimism.abi.pinax.network/api",
           "kind": "etherscan"
+        },
+        {
+          "url": "https://optimism.blockscout.com/api",
+          "kind": "blockscout"
         }
       ],
       "services": {
         "subgraphs": [
-          "https://api.thegraph.com/deploy"
+          "https://api.studio.thegraph.com/deploy"
         ],
-        "sps": [
-          "https://api.thegraph.com/deploy"
-        ],
+        "sps": [],
         "firehose": [
-          "opt-mainnet.streamingfast.io:443",
+          "mainnet.optimism.streamingfast.io:443",
           "optimism.firehose.pinax.network:443"
         ],
         "substreams": [
-          "opt-mainnet.streamingfast.io:443",
+          "mainnet.optimism.streamingfast.io:443",
           "optimism.substreams.pinax.network:443"
+        ],
+        "tokenApi": [
+          "https://token-api.thegraph.com"
         ]
       },
       "networkType": "mainnet",
@@ -135,22 +157,34 @@
       "indexerDocsUrls": [
         {
           "url": "https://docs.infradao.com/archive-nodes-101/optimism",
-          "description": "Arhchive Nodes 101"
+          "description": "Archive Nodes 101"
         }
       ],
-      "genesis": {
-        "hash": "0x7ca38a1916c42007829c55e69d3e9a73265554b586a499015373241b8a3fa48b",
-        "height": 0
-      },
       "firehose": {
         "blockType": "sf.ethereum.type.v2.Block",
-        "evmExtendedModel": false,
+        "evmExtendedModel": true,
         "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
-        "bytesEncoding": "hex"
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0x7ca38a1916c42007829c55e69d3e9a73265554b586a499015373241b8a3fa48b",
+          "height": 0
+        },
+        "blockFeatures": [
+          "extended@105235064",
+          "hybrid"
+        ]
+      },
+      "tokenApi": {
+        "features": [
+          "tokens",
+          "dexes",
+          "nfts"
+        ],
+        "networkId": "optimism"
       },
       "icon": {
         "web3Icons": {
-          "name": "optimistic-ethereum"
+          "name": "optimism"
         }
       }
     },
@@ -160,7 +194,8 @@
       "fullName": "Gnosis Mainnet",
       "aliases": [
         "evm-100",
-        "gnosis-mainnet"
+        "gnosis-mainnet",
+        "xdai"
       ],
       "caip2Id": "eip155:100",
       "graphNode": {
@@ -172,19 +207,22 @@
       ],
       "rpcUrls": [
         "https://rpc.gnosischain.com",
-        "https://gnosis.rpc.pinax.network/v1/{PINAX_API_KEY}",
-        "https://rpc.gnosis.gateway.fm",
-        "https://rpc.ankr.com/gnosis"
+        "https://gnosis.rpc.service.pinax.network",
+        "https://rpc.gnosis.gateway.fm"
       ],
       "apiUrls": [
         {
           "url": "https://gnosis.abi.pinax.network/api",
           "kind": "etherscan"
+        },
+        {
+          "url": "https://gnosis.blockscout.com/api",
+          "kind": "blockscout"
         }
       ],
       "services": {
         "subgraphs": [
-          "https://api.thegraph.com/deploy"
+          "https://api.studio.thegraph.com/deploy"
         ]
       },
       "networkType": "mainnet",
@@ -194,18 +232,21 @@
       "indexerDocsUrls": [
         {
           "url": "https://docs.infradao.com/archive-nodes-101/gnosis",
-          "description": "Arhchive Nodes 101"
+          "description": "Archive Nodes 101"
         }
       ],
-      "genesis": {
-        "hash": "0x4f1dd23188aab3a76b463e4af801b52b1248ef073c648cbdc4c9333d3da79756",
-        "height": 0
-      },
       "firehose": {
         "blockType": "sf.ethereum.type.v2.Block",
         "evmExtendedModel": false,
         "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
-        "bytesEncoding": "hex"
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0x4f1dd23188aab3a76b463e4af801b52b1248ef073c648cbdc4c9333d3da79756",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
       },
       "icon": {
         "web3Icons": {
@@ -231,10 +272,15 @@
       "rpcUrls": [
         "https://public-en-kairos.node.kaia.io"
       ],
-      "apiUrls": [],
+      "apiUrls": [
+        {
+          "url": "https://kaia-testnet.abi.pinax.network/api",
+          "kind": "etherscan"
+        }
+      ],
       "services": {
         "subgraphs": [
-          "https://api.thegraph.com/deploy"
+          "https://api.studio.thegraph.com/deploy"
         ]
       },
       "networkType": "testnet",
@@ -247,19 +293,131 @@
       "issuanceRewards": false,
       "nativeToken": "KAIA",
       "docsUrl": "https://docs.kaia.io",
-      "genesis": {
-        "hash": "0xe33ff05ceec2581ca9496f38a2bf9baad5d4eed629e896ccb33d1dc991bc4b4a",
-        "height": 0
-      },
       "firehose": {
         "blockType": "sf.ethereum.type.v2.Block",
         "evmExtendedModel": false,
         "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
-        "bytesEncoding": "hex"
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0xe33ff05ceec2581ca9496f38a2bf9baad5d4eed629e896ccb33d1dc991bc4b4a",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
       },
       "icon": {
         "web3Icons": {
-          "name": "klay-token"
+          "name": "kaia"
+        }
+      }
+    },
+    {
+      "id": "joc-testnet",
+      "shortName": "JOC",
+      "fullName": "Japan Open Chain Testnet",
+      "aliases": [
+        "evm-10081"
+      ],
+      "caip2Id": "eip155:10081",
+      "graphNode": {
+        "protocol": "ethereum"
+      },
+      "explorerUrls": [
+        "https://explorer.testnet.japanopenchain.org"
+      ],
+      "rpcUrls": [
+        "https://rpc-1.testnet.japanopenchain.org:8545"
+      ],
+      "apiUrls": [
+        {
+          "url": "https://explorer.testnet.japanopenchain.org/api",
+          "kind": "blockscout"
+        }
+      ],
+      "services": {
+        "subgraphs": [
+          "https://api.studio.thegraph.com/deploy"
+        ]
+      },
+      "networkType": "testnet",
+      "relations": [
+        {
+          "kind": "testnetOf",
+          "network": "joc"
+        }
+      ],
+      "issuanceRewards": false,
+      "nativeToken": "JOCT",
+      "docsUrl": "https://www.japanopenchain.org/en/developer",
+      "firehose": {
+        "blockType": "sf.ethereum.type.v2.Block",
+        "evmExtendedModel": false,
+        "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0x0fb7b4779aae36dc557227283f182bc9a3b232c07fae4a2553734c5817df1d06",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
+      },
+      "icon": {
+        "web3Icons": {
+          "name": "japan-open-chain"
+        }
+      }
+    },
+    {
+      "id": "monad-testnet",
+      "shortName": "Monad",
+      "fullName": "Monad Testnet",
+      "aliases": [
+        "evm-10143"
+      ],
+      "caip2Id": "eip155:10143",
+      "graphNode": {
+        "protocol": "ethereum"
+      },
+      "explorerUrls": [
+        "https://testnet.monadexplorer.com"
+      ],
+      "rpcUrls": [
+        "https://testnet-rpc.monad.xyz"
+      ],
+      "apiUrls": [
+        {
+          "url": "https://explorer.monad-testnet.category.xyz/api",
+          "kind": "blockscout"
+        }
+      ],
+      "services": {
+        "subgraphs": [
+          "https://api.studio.thegraph.com/deploy"
+        ]
+      },
+      "networkType": "testnet",
+      "relations": [],
+      "issuanceRewards": false,
+      "nativeToken": "MON",
+      "docsUrl": "https://docs.monad.xyz",
+      "firehose": {
+        "blockType": "sf.ethereum.type.v2.Block",
+        "evmExtendedModel": false,
+        "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0x1436534e54a22183ea29a2273b341cb50018ed066441ffd111cd263297caba35",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
+      },
+      "icon": {
+        "web3Icons": {
+          "name": "monad"
         }
       }
     },
@@ -280,17 +438,17 @@
       ],
       "rpcUrls": [
         "https://rpc.chiadochain.net",
-        "https://chiado.rpc.pinax.network/v1/{PINAX_API_KEY}"
+        "https://chiado.rpc.service.pinax.network"
       ],
       "apiUrls": [
         {
           "url": "https://gnosis-chiado.blockscout.com/api",
-          "kind": "etherscan"
+          "kind": "blockscout"
         }
       ],
       "services": {
         "subgraphs": [
-          "https://api.thegraph.com/deploy"
+          "https://api.studio.thegraph.com/deploy"
         ]
       },
       "networkType": "testnet",
@@ -303,15 +461,18 @@
       "issuanceRewards": false,
       "nativeToken": "XDAI",
       "docsUrl": "https://docs.gnosischain.com",
-      "genesis": {
-        "hash": "0xada44fd8d2ecab8b08f256af07ad3e777f17fb434f8f8e678b312f576212ba9a",
-        "height": 0
-      },
       "firehose": {
         "blockType": "sf.ethereum.type.v2.Block",
         "evmExtendedModel": false,
         "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
-        "bytesEncoding": "hex"
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0xada44fd8d2ecab8b08f256af07ad3e777f17fb434f8f8e678b312f576212ba9a",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
       },
       "icon": {
         "web3Icons": {
@@ -325,7 +486,8 @@
       "fullName": "CLV Parachain",
       "aliases": [
         "clv-mainnet",
-        "evm-1023"
+        "evm-1023",
+        "clover-mainnet"
       ],
       "caip2Id": "eip155:1023",
       "graphNode": {
@@ -340,27 +502,30 @@
       "apiUrls": [
         {
           "url": "https://clvscan.com/api",
-          "kind": "etherscan"
+          "kind": "blockscout"
         }
       ],
       "networkType": "mainnet",
       "services": {
         "subgraphs": [
-          "https://api.thegraph.com/deploy"
+          "https://api.studio.thegraph.com/deploy"
         ]
       },
       "issuanceRewards": false,
       "nativeToken": "CLV",
       "docsUrl": "https://docs.clv.org",
-      "genesis": {
-        "hash": "0x7c11fb21c186dd7846d92e09af5c02fa4c8a08b83c99d7361b8b9fd5dc1650fb",
-        "height": 1
-      },
       "firehose": {
         "blockType": "sf.ethereum.type.v2.Block",
         "evmExtendedModel": false,
         "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
-        "bytesEncoding": "hex"
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0x316ead04231197413e137d371f8763cf6db84400d43749853efba5006115783b",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
       },
       "icon": {
         "web3Icons": {
@@ -369,11 +534,74 @@
       }
     },
     {
+      "id": "metis",
+      "shortName": "Metis",
+      "secondName": "Andromeda",
+      "fullName": "Metis Andromeda Mainnet",
+      "aliases": [
+        "metis-mainnet",
+        "metis-andromeda",
+        "metis-andromeda-mainnet",
+        "evm-1088"
+      ],
+      "caip2Id": "eip155:1088",
+      "graphNode": {
+        "protocol": "ethereum"
+      },
+      "explorerUrls": [
+        "https://explorer.metis.io"
+      ],
+      "apiUrls": [
+        {
+          "url": "https://api.routescan.io/v2/network/mainnet/evm/1088/etherscan/api",
+          "kind": "etherscan"
+        }
+      ],
+      "rpcUrls": [
+        "https://andromeda.metis.io"
+      ],
+      "networkType": "mainnet",
+      "relations": [
+        {
+          "kind": "l2Of",
+          "network": "mainnet"
+        }
+      ],
+      "services": {
+        "subgraphs": [
+          "https://api.studio.thegraph.com/deploy"
+        ]
+      },
+      "issuanceRewards": false,
+      "nativeToken": "METIS",
+      "docsUrl": "https://docs.metis.io",
+      "firehose": {
+        "blockType": "sf.ethereum.type.v2.Block",
+        "evmExtendedModel": false,
+        "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0x9e3354e081a54a57190bdb8948a597c840ea5dd496b0322864d4585f4a716892",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
+      },
+      "icon": {
+        "web3Icons": {
+          "name": "metis-andromeda"
+        }
+      }
+    },
+    {
       "id": "polygon-zkevm",
-      "shortName": "Polygon",
-      "secondName": "zkEVM",
+      "shortName": "Polygon zkEVM",
       "fullName": "Polygon zkEVM Mainnet",
-      "aliases": [],
+      "aliases": [
+        "evm-1101",
+        "polygon-zkevm-mainnet"
+      ],
       "caip2Id": "eip155:1101",
       "graphNode": {
         "protocol": "ethereum"
@@ -389,22 +617,24 @@
       ],
       "rpcUrls": [
         "https://zkevm-rpc.com",
-        "https://polygonzk.rpc.pinax.network/v1/{PINAX_API_KEY}"
+        "https://polygonzk.rpc.service.pinax.network"
       ],
       "apiUrls": [
         {
           "url": "https://polygon-zkevm.abi.pinax.network/api",
           "kind": "etherscan"
+        },
+        {
+          "url": "https://zkevm.blockscout.com/api",
+          "kind": "blockscout"
         }
       ],
       "networkType": "mainnet",
       "services": {
         "subgraphs": [
-          "https://api.thegraph.com/deploy"
+          "https://api.studio.thegraph.com/deploy"
         ],
-        "sps": [
-          "https://api.thegraph.com/deploy"
-        ],
+        "sps": [],
         "firehose": [
           "polygonzk.firehose.pinax.network:443"
         ],
@@ -412,22 +642,101 @@
           "polygonzk.substreams.pinax.network:443"
         ]
       },
-      "issuanceRewards": false,
+      "issuanceRewards": true,
       "nativeToken": "ETH",
-      "docsUrl": "https://polygon.technology/polygon-zkevm",
-      "genesis": {
-        "hash": "0x81005434635456a16f74ff7023fbe0bf423abbc8a8deb093ffff455c0ad3b741",
-        "height": 0
-      },
+      "docsUrl": "https://docs.polygon.technology/zkEVM",
+      "indexerDocsUrls": [
+        {
+          "url": "https://docs.infradao.com/archive-nodes-101/polygon-zkevm",
+          "description": "Archive Nodes 101"
+        }
+      ],
       "firehose": {
         "blockType": "sf.ethereum.type.v2.Block",
         "evmExtendedModel": false,
         "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
-        "bytesEncoding": "hex"
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0x81005434635456a16f74ff7023fbe0bf423abbc8a8deb093ffff455c0ad3b741",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
       },
       "icon": {
         "web3Icons": {
           "name": "polygon-zkevm"
+        }
+      }
+    },
+    {
+      "id": "abstract-testnet",
+      "shortName": "Abstract",
+      "fullName": "Abstract Testnet",
+      "aliases": [
+        "evm-11124",
+        "abstract-sepolia"
+      ],
+      "caip2Id": "eip155:11124",
+      "graphNode": {
+        "protocol": "ethereum"
+      },
+      "explorerUrls": [
+        "https://explorer.testnet.abs.xyz"
+      ],
+      "rpcUrls": [
+        "https://api.testnet.abs.xyz"
+      ],
+      "apiUrls": [
+        {
+          "url": "https://block-explorer-api.testnet.abs.xyz/api",
+          "kind": "etherscan"
+        },
+        {
+          "url": "https://api.routescan.io/v2/network/testnet/evm/11124/etherscan/api",
+          "kind": "etherscan"
+        },
+        {
+          "url": "https://abstract-testnet.abi.pinax.network/api",
+          "kind": "etherscan"
+        }
+      ],
+      "services": {
+        "subgraphs": [
+          "https://api.studio.thegraph.com/deploy"
+        ]
+      },
+      "networkType": "testnet",
+      "relations": [
+        {
+          "kind": "testnetOf",
+          "network": "abstract"
+        },
+        {
+          "kind": "l2Of",
+          "network": "sepolia"
+        }
+      ],
+      "issuanceRewards": false,
+      "nativeToken": "ETH",
+      "docsUrl": "https://docs.abs.xyz",
+      "firehose": {
+        "blockType": "sf.ethereum.type.v2.Block",
+        "evmExtendedModel": false,
+        "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0xe8e77626586f73b955364c7b4bbf0bb7f7685ebd40e852b164633a4acbd3244c",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
+      },
+      "icon": {
+        "web3Icons": {
+          "name": "abstract"
         }
       }
     },
@@ -455,23 +764,29 @@
         "https://sepolia.otterscan.io"
       ],
       "rpcUrls": [
-        "https://rpc.sepolia.org",
-        "https://sepolia.rpc.pinax.network/v1/{PINAX_API_KEY}",
+        "https://sepolia.gateway.tenderly.co",
+        "https://sepolia.rpc.service.pinax.network",
         "https://sepolia.infura.io/v3/${INFURA_API_KEY}"
       ],
       "apiUrls": [
         {
           "url": "https://sepolia.abi.pinax.network/api",
           "kind": "etherscan"
+        },
+        {
+          "url": "https://eth-sepolia.blockscout.com/api",
+          "kind": "blockscout"
+        },
+        {
+          "url": "https://api.routescan.io/v2/network/testnet/evm/11155111/etherscan/api",
+          "kind": "etherscan"
         }
       ],
       "services": {
         "subgraphs": [
-          "https://api.thegraph.com/deploy"
+          "https://api.studio.thegraph.com/deploy"
         ],
-        "sps": [
-          "https://api.thegraph.com/deploy"
-        ],
+        "sps": [],
         "firehose": [
           "sepolia.firehose.pinax.network:443",
           "sepolia.eth.streamingfast.io:443"
@@ -484,15 +799,18 @@
       "issuanceRewards": false,
       "nativeToken": "ETH",
       "docsUrl": "https://sepolia.dev",
-      "genesis": {
-        "hash": "0x25a5cc106eea7138acab33231d7160d69cb777ee0c2c553fcddf5138993e6dd9",
-        "height": 0
-      },
       "firehose": {
         "blockType": "sf.ethereum.type.v2.Block",
         "evmExtendedModel": true,
         "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
-        "bytesEncoding": "hex"
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0x25a5cc106eea7138acab33231d7160d69cb777ee0c2c553fcddf5138993e6dd9",
+          "height": 0
+        },
+        "blockFeatures": [
+          "extended"
+        ]
       },
       "icon": {
         "web3Icons": {
@@ -528,17 +846,21 @@
       ],
       "rpcUrls": [
         "https://sepolia.optimism.io",
-        "https://opsepolia.rpc.pinax.network/v1/{PINAX_API_KEY}"
+        "https://opsepolia.rpc.service.pinax.network"
       ],
       "apiUrls": [
         {
           "url": "https://optimism-sepolia.abi.pinax.network/api",
           "kind": "etherscan"
+        },
+        {
+          "url": "https://optimism-sepolia.blockscout.com/api",
+          "kind": "blockscout"
         }
       ],
       "services": {
         "subgraphs": [
-          "https://api.thegraph.com/deploy"
+          "https://api.studio.thegraph.com/deploy"
         ],
         "firehose": [
           "opsepolia.firehose.pinax.network:443"
@@ -548,22 +870,25 @@
         ]
       },
       "networkType": "testnet",
-      "issuanceRewards": false,
+      "issuanceRewards": true,
       "nativeToken": "ETH",
       "docsUrl": "https://docs.optimism.io",
-      "genesis": {
-        "hash": "0x102de6ffb001480cc9b8b548fd05c34cd4f46ae4aa91759393db90ea0409887d",
-        "height": 0
-      },
       "firehose": {
         "blockType": "sf.ethereum.type.v2.Block",
-        "evmExtendedModel": false,
+        "evmExtendedModel": true,
         "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
-        "bytesEncoding": "hex"
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0x102de6ffb001480cc9b8b548fd05c34cd4f46ae4aa91759393db90ea0409887d",
+          "height": 0
+        },
+        "blockFeatures": [
+          "extended"
+        ]
       },
       "icon": {
         "web3Icons": {
-          "name": "optimistic-ethereum"
+          "name": "optimism"
         }
       }
     },
@@ -592,7 +917,7 @@
       ],
       "services": {
         "subgraphs": [
-          "https://api.thegraph.com/deploy"
+          "https://api.studio.thegraph.com/deploy"
         ]
       },
       "networkType": "testnet",
@@ -605,15 +930,18 @@
       "issuanceRewards": false,
       "nativeToken": "ETH",
       "docsUrl": "https://docs.fuse.io",
-      "genesis": {
-        "hash": "0xfd643f387cd7386d21e8d34f8762188865789196dee77c98f8210dbbc15616ae",
-        "height": 0
-      },
       "firehose": {
         "blockType": "sf.ethereum.type.v2.Block",
         "evmExtendedModel": false,
         "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
-        "bytesEncoding": "hex"
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0xfd643f387cd7386d21e8d34f8762188865789196dee77c98f8210dbbc15616ae",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
       },
       "icon": {
         "web3Icons": {
@@ -638,7 +966,7 @@
       ],
       "rpcUrls": [
         "https://rpc.fuse.io",
-        "https://fuse.rpc.pinax.network/v1/{PINAX_API_KEY}"
+        "https://fuse.rpc.service.pinax.network"
       ],
       "apiUrls": [
         {
@@ -648,11 +976,9 @@
       ],
       "services": {
         "subgraphs": [
-          "https://api.thegraph.com/deploy"
+          "https://api.studio.thegraph.com/deploy"
         ],
-        "sps": [
-          "https://api.thegraph.com/deploy"
-        ],
+        "sps": [],
         "firehose": [
           "fuse.firehose.pinax.network:443"
         ],
@@ -667,18 +993,21 @@
       "indexerDocsUrls": [
         {
           "url": "https://docs.infradao.com/archive-nodes-101/fuse",
-          "description": "Arhchive Nodes 101"
+          "description": "Archive Nodes 101"
         }
       ],
-      "genesis": {
-        "hash": "0x6e778e9491576a28bd06fac93844d8494be1f153e60ba7d29b4b51d991d4f830",
-        "height": 0
-      },
       "firehose": {
         "blockType": "sf.ethereum.type.v2.Block",
         "evmExtendedModel": false,
         "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
-        "bytesEncoding": "hex"
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0x6e778e9491576a28bd06fac93844d8494be1f153e60ba7d29b4b51d991d4f830",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
       },
       "icon": {
         "web3Icons": {
@@ -711,7 +1040,7 @@
       ],
       "services": {
         "subgraphs": [
-          "https://api.thegraph.com/deploy"
+          "https://api.studio.thegraph.com/deploy"
         ]
       },
       "networkType": "testnet",
@@ -724,15 +1053,18 @@
       "issuanceRewards": false,
       "nativeToken": "GAS",
       "docsUrl": "https://xdocs.ngd.network",
-      "genesis": {
-        "hash": "0x221f7d0a47dd80fe10f476625d62303947c9cd336113e119c64d919f0e9beb71",
-        "height": 0
-      },
       "firehose": {
         "blockType": "sf.ethereum.type.v2.Block",
         "evmExtendedModel": false,
         "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
-        "bytesEncoding": "hex"
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0x221f7d0a47dd80fe10f476625d62303947c9cd336113e119c64d919f0e9beb71",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
       },
       "icon": {
         "web3Icons": {
@@ -758,12 +1090,12 @@
       "apiUrls": [
         {
           "url": "https://testnet.explorer.etherlink.com/api",
-          "kind": "etherscan"
+          "kind": "blockscout"
         }
       ],
       "services": {
         "subgraphs": [
-          "https://api.thegraph.com/deploy"
+          "https://api.studio.thegraph.com/deploy"
         ]
       },
       "networkType": "testnet",
@@ -776,15 +1108,18 @@
       "issuanceRewards": false,
       "nativeToken": "XTZ",
       "docsUrl": "https://docs.etherlink.com",
-      "genesis": {
-        "hash": "0x2cf11372c813c0007ef080103fc813cf26ad9a374e88d589ef536dfc3dd1fee9",
-        "height": 0
-      },
       "firehose": {
         "blockType": "sf.ethereum.type.v2.Block",
         "evmExtendedModel": false,
         "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
-        "bytesEncoding": "hex"
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0x2cf11372c813c0007ef080103fc813cf26ad9a374e88d589ef536dfc3dd1fee9",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
       },
       "icon": {
         "web3Icons": {
@@ -798,7 +1133,8 @@
       "fullName": "Moonbeam Mainnet",
       "aliases": [
         "evm-1284",
-        "mbeam"
+        "mbeam",
+        "moonbeam-mainnet"
       ],
       "caip2Id": "eip155:1284",
       "graphNode": {
@@ -809,7 +1145,7 @@
       ],
       "rpcUrls": [
         "https://rpc.api.moonbeam.network",
-        "https://moonbeam.rpc.pinax.network/v1/{PINAX_API_KEY}"
+        "https://moonbeam.rpc.service.pinax.network"
       ],
       "apiUrls": [
         {
@@ -819,7 +1155,7 @@
       ],
       "services": {
         "subgraphs": [
-          "https://api.thegraph.com/deploy"
+          "https://api.studio.thegraph.com/deploy"
         ],
         "firehose": [
           "moonbeam.firehose.pinax.network:443"
@@ -829,24 +1165,27 @@
         ]
       },
       "networkType": "mainnet",
-      "issuanceRewards": false,
+      "issuanceRewards": true,
       "nativeToken": "GLMR",
       "docsUrl": "https://docs.moonbeam.network",
       "indexerDocsUrls": [
         {
           "url": "https://docs.infradao.com/archive-nodes-101/moonbeam",
-          "description": "Arhchive Nodes 101"
+          "description": "Archive Nodes 101"
         }
       ],
-      "genesis": {
-        "hash": "0x7e6b3bbed86828a558271c9c9f62354b1d8b5aa15ff85fd6f1e7cbe9af9dde7e",
-        "height": 0
-      },
       "firehose": {
         "blockType": "sf.ethereum.type.v2.Block",
         "evmExtendedModel": false,
         "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
-        "bytesEncoding": "hex"
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0x7e6b3bbed86828a558271c9c9f62354b1d8b5aa15ff85fd6f1e7cbe9af9dde7e",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
       },
       "icon": {
         "web3Icons": {
@@ -860,7 +1199,8 @@
       "fullName": "Moonriver Mainnet",
       "aliases": [
         "evm-1285",
-        "mriver"
+        "mriver",
+        "moonriver-mainnet"
       ],
       "caip2Id": "eip155:1285",
       "graphNode": {
@@ -871,18 +1211,18 @@
       ],
       "rpcUrls": [
         "https://rpc.api.moonriver.moonbeam.network",
-        "https://moonriver.rpc.pinax.network/v1/{PINAX_API_KEY}",
+        "https://moonriver.rpc.service.pinax.network",
         "https://moonriver.public.blastapi.io"
       ],
       "apiUrls": [
         {
-          "url": "https://api-moonriver.moonscan.io/api",
+          "url": "https://moonriver.abi.pinax.network/api",
           "kind": "etherscan"
         }
       ],
       "services": {
         "subgraphs": [
-          "https://api.thegraph.com/deploy"
+          "https://api.studio.thegraph.com/deploy"
         ],
         "firehose": [
           "moonriver.firehose.pinax.network:443"
@@ -901,23 +1241,22 @@
       "issuanceRewards": false,
       "nativeToken": "MOVR",
       "docsUrl": "https://docs.moonbeam.network",
-      "genesis": {
-        "hash": "0xce24348303f7a60c4d2d3c82adddf55ca57af89cd9e2cd4b863906ef53b89b3c",
-        "height": 0
-      },
       "firehose": {
         "blockType": "sf.ethereum.type.v2.Block",
         "evmExtendedModel": false,
         "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
-        "bytesEncoding": "hex"
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0xce24348303f7a60c4d2d3c82adddf55ca57af89cd9e2cd4b863906ef53b89b3c",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
       },
       "icon": {
         "web3Icons": {
-          "name": "moonriver",
-          "variants": [
-            "mono",
-            "branded"
-          ]
+          "name": "moonriver"
         }
       }
     },
@@ -948,7 +1287,7 @@
       ],
       "services": {
         "subgraphs": [
-          "https://api.thegraph.com/deploy"
+          "https://api.studio.thegraph.com/deploy"
         ]
       },
       "networkType": "testnet",
@@ -961,19 +1300,152 @@
       "issuanceRewards": false,
       "nativeToken": "DEV",
       "docsUrl": "https://docs.moonbeam.network/learn/platform/networks/moonbase",
-      "genesis": {
-        "hash": "0x33638dde636f9264b6472b9d976d58e757fe88badac53f204f3f530ecc5aacfa",
-        "height": 0
-      },
       "firehose": {
         "blockType": "sf.ethereum.type.v2.Block",
         "evmExtendedModel": false,
         "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
-        "bytesEncoding": "hex"
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0x33638dde636f9264b6472b9d976d58e757fe88badac53f204f3f530ecc5aacfa",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
       },
       "icon": {
         "web3Icons": {
           "name": "moonbeam"
+        }
+      }
+    },
+    {
+      "id": "katana-tatara",
+      "shortName": "Katana",
+      "fullName": "Katana Tatara Testnet",
+      "aliases": [
+        "evm-129399"
+      ],
+      "caip2Id": "eip155:129399",
+      "graphNode": {
+        "protocol": "ethereum"
+      },
+      "explorerUrls": [
+        "https://explorer.tatara.katana.network"
+      ],
+      "rpcUrls": [
+        "https://rpc.tatara.katanarpc.com"
+      ],
+      "apiUrls": [
+        {
+          "url": "https://explorer.tatara.katana.network/api",
+          "kind": "etherscan"
+        }
+      ],
+      "services": {
+        "subgraphs": [
+          "https://api.studio.thegraph.com/deploy"
+        ]
+      },
+      "networkType": "testnet",
+      "relations": [
+        {
+          "kind": "l2Of",
+          "network": "sepolia"
+        },
+        {
+          "kind": "testnetOf",
+          "network": "katana"
+        }
+      ],
+      "issuanceRewards": false,
+      "nativeToken": "ETH",
+      "firehose": {
+        "blockType": "sf.ethereum.type.v2.Block",
+        "evmExtendedModel": false,
+        "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0xbca38f4936fefe65751e55b3f3f88fec27d478e283b6bb92b5268e2ffcea7716",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
+      },
+      "icon": {
+        "web3Icons": {
+          "name": "katana"
+        }
+      }
+    },
+    {
+      "id": "unichain",
+      "shortName": "Unichain",
+      "fullName": "Unichain Mainnet",
+      "aliases": [
+        "evm-130",
+        "unichain-mainnet"
+      ],
+      "caip2Id": "eip155:130",
+      "graphNode": {
+        "protocol": "ethereum"
+      },
+      "services": {
+        "subgraphs": [
+          "https://api.studio.thegraph.com/deploy"
+        ],
+        "firehose": [
+          "unichain.firehose.pinax.network:443"
+        ],
+        "substreams": [
+          "unichain.substreams.pinax.network:443"
+        ]
+      },
+      "networkType": "mainnet",
+      "relations": [
+        {
+          "kind": "l2Of",
+          "network": "mainnet"
+        }
+      ],
+      "explorerUrls": [
+        "https://unichain.blockscout.com",
+        "https://uniscan.xyz"
+      ],
+      "apiUrls": [
+        {
+          "url": "https://unichain.blockscout.com/api",
+          "kind": "blockscout"
+        },
+        {
+          "url": "https://unichain.abi.pinax.network/api",
+          "kind": "etherscan"
+        }
+      ],
+      "rpcUrls": [
+        "https://mainnet.unichain.org",
+        "https://unichain.rpc.service.pinax.network"
+      ],
+      "issuanceRewards": false,
+      "nativeToken": "ETH",
+      "docsUrl": "https://docs.unichain.org/docs",
+      "firehose": {
+        "blockType": "sf.ethereum.type.v2.Block",
+        "evmExtendedModel": true,
+        "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0x3425162ddf41a0a1f0106d67b71828c9a9577e6ddeb94e4f33d2cde1fdc3befe",
+          "height": 0
+        },
+        "blockFeatures": [
+          "extended"
+        ]
+      },
+      "icon": {
+        "web3Icons": {
+          "name": "unichain"
         }
       }
     },
@@ -983,18 +1455,19 @@
       "secondName": "Sepolia",
       "fullName": "Unichain Sepolia Testnet",
       "aliases": [
-        "evm-1301"
+        "evm-1301",
+        "unichain-sepolia"
       ],
       "caip2Id": "eip155:1301",
       "networkType": "testnet",
       "relations": [
         {
-          "kind": "testnetOf",
-          "network": "unichain-testnet"
-        },
-        {
           "kind": "l2Of",
           "network": "sepolia"
+        },
+        {
+          "kind": "testnetOf",
+          "network": "unichain"
         }
       ],
       "graphNode": {
@@ -1005,21 +1478,27 @@
       ],
       "rpcUrls": [
         "https://sepolia.unichain.org",
-        "https://unisepolia.rpc.pinax.network/v1/{PINAX_API_KEY}"
+        "https://unisepolia.rpc.service.pinax.network"
       ],
       "apiUrls": [
         {
           "url": "https://unichain-sepolia.blockscout.com/api",
+          "kind": "blockscout"
+        },
+        {
+          "url": "https://api.routescan.io/v2/network/testnet/evm/1301/etherscan/api",
+          "kind": "etherscan"
+        },
+        {
+          "url": "https://unichain-testnet.abi.pinax.network/api",
           "kind": "etherscan"
         }
       ],
       "services": {
         "subgraphs": [
-          "https://api.thegraph.com/deploy"
+          "https://api.studio.thegraph.com/deploy"
         ],
-        "sps": [
-          "https://api.thegraph.com/deploy"
-        ],
+        "sps": [],
         "firehose": [
           "unisepolia.firehose.pinax.network:443"
         ],
@@ -1030,15 +1509,18 @@
       "issuanceRewards": false,
       "nativeToken": "ETH",
       "docsUrl": "https://docs.unichain.org",
-      "genesis": {
-        "hash": "0xb7fe0bc9f98ca03294ca0094ff9374cc3e64130b6ec85850d6e260191f48bfe7",
-        "height": 0
-      },
       "firehose": {
         "blockType": "sf.ethereum.type.v2.Block",
         "evmExtendedModel": true,
         "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
-        "bytesEncoding": "hex"
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0xb7fe0bc9f98ca03294ca0094ff9374cc3e64130b6ec85850d6e260191f48bfe7",
+          "height": 0
+        },
+        "blockFeatures": [
+          "extended"
+        ]
       },
       "icon": {
         "web3Icons": {
@@ -1067,27 +1549,30 @@
       "apiUrls": [
         {
           "url": "https://explorer.mainnet.aurora.dev/api",
-          "kind": "etherscan"
+          "kind": "blockscout"
         }
       ],
       "services": {
         "subgraphs": [
-          "https://api.thegraph.com/deploy"
+          "https://api.studio.thegraph.com/deploy"
         ]
       },
       "networkType": "mainnet",
       "issuanceRewards": false,
       "nativeToken": "ETH",
       "docsUrl": "https://doc.aurora.dev",
-      "genesis": {
-        "hash": "0x0475c3f1fb767b161d8691d243a8daa3ff1621c181d21ca215b327d72df7fd11",
-        "height": 0
-      },
       "firehose": {
         "blockType": "sf.ethereum.type.v2.Block",
         "evmExtendedModel": false,
         "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
-        "bytesEncoding": "hex"
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0x0475c3f1fb767b161d8691d243a8daa3ff1621c181d21ca215b327d72df7fd11",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
       },
       "icon": {
         "web3Icons": {
@@ -1115,12 +1600,12 @@
       "apiUrls": [
         {
           "url": "https://explorer.testnet.aurora.dev/api",
-          "kind": "etherscan"
+          "kind": "blockscout"
         }
       ],
       "services": {
         "subgraphs": [
-          "https://api.thegraph.com/deploy"
+          "https://api.studio.thegraph.com/deploy"
         ]
       },
       "networkType": "testnet",
@@ -1133,15 +1618,18 @@
       "issuanceRewards": false,
       "nativeToken": "ETH",
       "docsUrl": "https://doc.aurora.dev",
-      "genesis": {
-        "hash": "0x250d32dc5dc0113f25f82987daf09e1dc5a79b09e53e78d475728f71248767b0",
-        "height": 0
-      },
       "firehose": {
         "blockType": "sf.ethereum.type.v2.Block",
         "evmExtendedModel": false,
         "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
-        "bytesEncoding": "hex"
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0x250d32dc5dc0113f25f82987daf09e1dc5a79b09e53e78d475728f71248767b0",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
       },
       "icon": {
         "web3Icons": {
@@ -1176,7 +1664,7 @@
       ],
       "services": {
         "subgraphs": [
-          "https://api.thegraph.com/deploy"
+          "https://api.studio.thegraph.com/deploy"
         ]
       },
       "networkType": "testnet",
@@ -1189,15 +1677,18 @@
       "issuanceRewards": false,
       "nativeToken": "SEI",
       "docsUrl": "https://docs.seitrace.com",
-      "genesis": {
-        "hash": "0xf9d3845df25b43b1c6926f3ceda6845c17f5624e12212fd8847d0ba01da1ab9e",
-        "height": 0
-      },
       "firehose": {
         "blockType": "sf.ethereum.type.v2.Block",
-        "evmExtendedModel": false,
+        "evmExtendedModel": true,
         "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
-        "bytesEncoding": "hex"
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0xf9d3845df25b43b1c6926f3ceda6845c17f5624e12212fd8847d0ba01da1ab9e",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
       },
       "icon": {
         "web3Icons": {
@@ -1231,7 +1722,7 @@
       ],
       "services": {
         "subgraphs": [
-          "https://api.thegraph.com/deploy"
+          "https://api.studio.thegraph.com/deploy"
         ],
         "firehose": [
           "evm-mainnet.sei.streamingfast.io:443"
@@ -1244,19 +1735,85 @@
       "issuanceRewards": false,
       "nativeToken": "SEI",
       "docsUrl": "https://docs.seitrace.com",
-      "genesis": {
-        "hash": "0xe43c3e52a4f74dc7bb35f55cc813ed2ce97e46aafb3fcf8884056b0a757f5b75",
-        "height": 79123881
-      },
       "firehose": {
         "blockType": "sf.ethereum.type.v2.Block",
-        "evmExtendedModel": false,
+        "evmExtendedModel": true,
         "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
-        "bytesEncoding": "hex"
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0xe43c3e52a4f74dc7bb35f55cc813ed2ce97e46aafb3fcf8884056b0a757f5b75",
+          "height": 79123881
+        },
+        "blockFeatures": [
+          "base"
+        ]
       },
       "icon": {
         "web3Icons": {
           "name": "sei-network"
+        }
+      }
+    },
+    {
+      "id": "hashkeychain-sepolia",
+      "shortName": "Hashkey Chain",
+      "secondName": "Sepolia",
+      "fullName": "Hashkey Chain Sepolia Testnet",
+      "aliases": [
+        "hashkeychain-testnet",
+        "evm-133"
+      ],
+      "caip2Id": "eip155:133",
+      "graphNode": {
+        "protocol": "ethereum"
+      },
+      "explorerUrls": [
+        "https://hashkeychain-testnet-explorer.alt.technology"
+      ],
+      "apiUrls": [
+        {
+          "url": "https://hashkeychain-testnet-explorer.alt.technology/api",
+          "kind": "etherscan"
+        }
+      ],
+      "rpcUrls": [
+        "https://hashkeychain-testnet.alt.technology"
+      ],
+      "networkType": "testnet",
+      "relations": [
+        {
+          "kind": "l2Of",
+          "network": "sepolia"
+        },
+        {
+          "kind": "testnetOf",
+          "network": "hashkeychain"
+        }
+      ],
+      "services": {
+        "subgraphs": [
+          "https://api.studio.thegraph.com/deploy"
+        ]
+      },
+      "issuanceRewards": false,
+      "nativeToken": "HSK",
+      "docsUrl": "https://docs.hsk.xyz",
+      "firehose": {
+        "blockType": "sf.ethereum.type.v2.Block",
+        "evmExtendedModel": false,
+        "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0x656cb2200b3dd0ac9434a86aa8db62fe1a0f317be4086cc5fe80c7c36645ed8c",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
+      },
+      "icon": {
+        "web3Icons": {
+          "name": "hashkey"
         }
       }
     },
@@ -1286,7 +1843,7 @@
       ],
       "services": {
         "subgraphs": [
-          "https://api.thegraph.com/deploy"
+          "https://api.studio.thegraph.com/deploy"
         ]
       },
       "networkType": "testnet",
@@ -1303,15 +1860,18 @@
       "issuanceRewards": false,
       "nativeToken": "G",
       "docsUrl": "https://docs.gravity.xyz",
-      "genesis": {
-        "hash": "0xdf76dabe0734fed9d517027a494bc00662576d30aee9672a6fab5184e06ee8ca",
-        "height": 0
-      },
       "firehose": {
         "blockType": "sf.ethereum.type.v2.Block",
-        "evmExtendedModel": false,
+        "evmExtendedModel": true,
         "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
-        "bytesEncoding": "hex"
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0xdf76dabe0734fed9d517027a494bc00662576d30aee9672a6fab5184e06ee8ca",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
       },
       "icon": {
         "web3Icons": {
@@ -1342,23 +1902,25 @@
       ],
       "rpcUrls": [
         "https://polygon-rpc.com",
-        "https://polygon.rpc.pinax.network/v1/{PINAX_API_KEY}",
+        "https://polygon.rpc.service.pinax.network",
         "https://rpc.ankr.com/polygon"
       ],
       "apiUrls": [
         {
-          "url": "https://api.polygonscan.com/api",
+          "url": "https://polygon.abi.pinax.network/api",
           "kind": "etherscan"
+        },
+        {
+          "url": "https://polygon.blockscout.com/api",
+          "kind": "blockscout"
         }
       ],
       "networkType": "mainnet",
       "services": {
         "subgraphs": [
-          "https://api.thegraph.com/deploy"
+          "https://api.studio.thegraph.com/deploy"
         ],
-        "sps": [
-          "https://api.thegraph.com/deploy"
-        ],
+        "sps": [],
         "firehose": [
           "polygon.firehose.pinax.network:443",
           "polygon.streamingfast.io:443"
@@ -1366,30 +1928,223 @@
         "substreams": [
           "polygon.substreams.pinax.network:443",
           "polygon.streamingfast.io:443"
+        ],
+        "tokenApi": [
+          "https://token-api.thegraph.com"
         ]
       },
       "indexerDocsUrls": [
         {
           "url": "https://docs.infradao.com/archive-nodes-101/polygon",
-          "description": "Arhchive Nodes 101"
+          "description": "Archive Nodes 101"
         }
       ],
       "issuanceRewards": true,
       "nativeToken": "POL",
       "docsUrl": "https://docs.polygon.technology",
-      "genesis": {
-        "hash": "0xa9c28ce2141b56c474f1dc504bee9b01eb1bd7d1a507580d5519d4437a97de1b",
-        "height": 0
-      },
       "firehose": {
         "blockType": "sf.ethereum.type.v2.Block",
         "evmExtendedModel": true,
         "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
-        "bytesEncoding": "hex"
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0xa9c28ce2141b56c474f1dc504bee9b01eb1bd7d1a507580d5519d4437a97de1b",
+          "height": 0
+        },
+        "blockFeatures": [
+          "extended"
+        ]
+      },
+      "tokenApi": {
+        "features": [
+          "tokens",
+          "dexes",
+          "nfts"
+        ],
+        "networkId": "matic"
       },
       "icon": {
         "web3Icons": {
-          "name": "polygon-pos"
+          "name": "polygon"
+        }
+      }
+    },
+    {
+      "id": "sonic",
+      "shortName": "Sonic",
+      "fullName": "Sonic Mainnet",
+      "aliases": [
+        "evm-146",
+        "sonic-mainnet"
+      ],
+      "caip2Id": "eip155:146",
+      "graphNode": {
+        "protocol": "ethereum"
+      },
+      "explorerUrls": [
+        "https://sonicscan.org"
+      ],
+      "rpcUrls": [
+        "https://rpc.soniclabs.com",
+        "https://sonic.rpc.service.pinax.network"
+      ],
+      "apiUrls": [
+        {
+          "url": "https://api.routescan.io/v2/network/mainnet/evm/146/etherscan/api",
+          "kind": "etherscan"
+        },
+        {
+          "url": "https://sonic.abi.pinax.network/api",
+          "kind": "etherscan"
+        }
+      ],
+      "services": {
+        "subgraphs": [
+          "https://api.studio.thegraph.com/deploy"
+        ],
+        "firehose": [
+          "sonic.firehose.pinax.network:443"
+        ],
+        "substreams": [
+          "sonic.substreams.pinax.network:443"
+        ]
+      },
+      "networkType": "mainnet",
+      "issuanceRewards": true,
+      "nativeToken": "S",
+      "docsUrl": "https://docs.soniclabs.com",
+      "indexerDocsUrls": [
+        {
+          "url": "https://docs.infradao.com/archive-nodes-101/sonic",
+          "description": "Archive Nodes 101"
+        }
+      ],
+      "firehose": {
+        "blockType": "sf.ethereum.type.v2.Block",
+        "evmExtendedModel": false,
+        "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0x411c75a1b1c2f2f458bcf243e7743d114e0117a4233cc13d91e7efc8fe8b0f3b",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
+      },
+      "icon": {
+        "web3Icons": {
+          "name": "sonic"
+        }
+      }
+    },
+    {
+      "id": "vana",
+      "shortName": "Vana",
+      "fullName": "Vana Mainnet",
+      "aliases": [
+        "evm-1480",
+        "vana-mainnet"
+      ],
+      "caip2Id": "eip155:1480",
+      "graphNode": {
+        "protocol": "ethereum"
+      },
+      "explorerUrls": [
+        "https://vanascan.io"
+      ],
+      "rpcUrls": [
+        "https://rpc.vana.org"
+      ],
+      "apiUrls": [
+        {
+          "url": "https://vanascan.io/api",
+          "kind": "blockscout"
+        }
+      ],
+      "services": {
+        "subgraphs": [
+          "https://api.studio.thegraph.com/deploy"
+        ]
+      },
+      "networkType": "mainnet",
+      "issuanceRewards": false,
+      "nativeToken": "VANA",
+      "docsUrl": "https://docs.vana.org",
+      "firehose": {
+        "blockType": "sf.ethereum.type.v2.Block",
+        "evmExtendedModel": true,
+        "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0xcf48ae63008a2a6ccf05c45dc3f8a4d99595999eafd09fa925d3906e4c4ff72b",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
+      },
+      "icon": {
+        "web3Icons": {
+          "name": "vana"
+        }
+      }
+    },
+    {
+      "id": "vana-moksha",
+      "shortName": "Vana",
+      "fullName": "Vana Moksha Testnet",
+      "aliases": [
+        "vana-testnet",
+        "evm-14800"
+      ],
+      "caip2Id": "eip155:14800",
+      "graphNode": {
+        "protocol": "ethereum"
+      },
+      "rpcUrls": [
+        "https://rpc.moksha.vana.org"
+      ],
+      "explorerUrls": [
+        "https://moksha.vanascan.io"
+      ],
+      "apiUrls": [
+        {
+          "url": "https://api.moksha.vanascan.io/api",
+          "kind": "etherscan"
+        }
+      ],
+      "networkType": "testnet",
+      "relations": [
+        {
+          "kind": "testnetOf",
+          "network": "vana"
+        }
+      ],
+      "services": {
+        "subgraphs": [
+          "https://api.studio.thegraph.com/deploy"
+        ]
+      },
+      "issuanceRewards": false,
+      "nativeToken": "VANA",
+      "docsUrl": "https://docs.vana.org",
+      "firehose": {
+        "blockType": "sf.ethereum.type.v2.Block",
+        "evmExtendedModel": true,
+        "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0xaaa9e377da2dad6ec5896b5fdce820efc24643e40687a36c51a17ffac892726b",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
+      },
+      "icon": {
+        "web3Icons": {
+          "name": "vana"
         }
       }
     },
@@ -1422,7 +2177,7 @@
       ],
       "rpcUrls": [
         "https://api.testnet.evm.eosnetwork.com",
-        "https://jungle4evm.rpc.pinax.network/v1/{PINAX_API_KEY}"
+        "https://jungle4evm.rpc.service.pinax.network"
       ],
       "apiUrls": [
         {
@@ -1442,15 +2197,18 @@
       "issuanceRewards": false,
       "nativeToken": "EOS",
       "docsUrl": "https://eosnetwork.com/eos-evm",
-      "genesis": {
-        "hash": "0xc6f7c5c995ae7a7567b44e9679c6654b39a957fe33daa33aee4ee96a01b2fbd5",
-        "height": 0
-      },
       "firehose": {
         "blockType": "sf.ethereum.type.v2.Block",
-        "evmExtendedModel": true,
+        "evmExtendedModel": false,
         "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
-        "bytesEncoding": "hex"
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0xc6f7c5c995ae7a7567b44e9679c6654b39a957fe33daa33aee4ee96a01b2fbd5",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
       },
       "icon": {
         "web3Icons": {
@@ -1475,7 +2233,7 @@
       ],
       "rpcUrls": [
         "https://rpc.gravity.xyz",
-        "https://gravity.rpc.pinax.network/v1/{PINAX_API_KEY}"
+        "https://gravity.rpc.service.pinax.network"
       ],
       "apiUrls": [
         {
@@ -1483,9 +2241,15 @@
           "kind": "etherscan"
         }
       ],
+      "relations": [
+        {
+          "kind": "l2Of",
+          "network": "mainnet"
+        }
+      ],
       "services": {
         "subgraphs": [
-          "https://api.thegraph.com/deploy"
+          "https://api.studio.thegraph.com/deploy"
         ],
         "firehose": [
           "gravity.firehose.pinax.network:443"
@@ -1495,29 +2259,80 @@
         ]
       },
       "networkType": "mainnet",
-      "relations": [
-        {
-          "kind": "l2Of",
-          "network": "mainnet"
-        }
-      ],
       "issuanceRewards": false,
       "nativeToken": "G",
       "docsUrl": "https://docs.gravity.xyz",
-      "genesis": {
-        "hash": "0x6eb5f2e11f3e026992cb3860e4518f672f0019fdc3c595e06cd22894fb6d7c36",
-        "height": 0
-      },
       "firehose": {
         "blockType": "sf.ethereum.type.v2.Block",
-        "evmExtendedModel": false,
+        "evmExtendedModel": true,
         "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
-        "bytesEncoding": "hex"
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0x6eb5f2e11f3e026992cb3860e4518f672f0019fdc3c595e06cd22894fb6d7c36",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
       },
       "icon": {
         "web3Icons": {
           "name": "gravity"
         }
+      }
+    },
+    {
+      "id": "status-sepolia",
+      "shortName": "Status",
+      "secondName": "Sepolia",
+      "fullName": "Status Network Sepolia",
+      "aliases": [
+        "status-testnet",
+        "evm-1660990954"
+      ],
+      "caip2Id": "eip155:1660990954",
+      "graphNode": {
+        "protocol": "ethereum"
+      },
+      "explorerUrls": [
+        "https://sepoliascan.status.network"
+      ],
+      "rpcUrls": [
+        "https://public.sepolia.rpc.status.network"
+      ],
+      "apiUrls": [
+        {
+          "url": "https://sepoliascan.status.network/api",
+          "kind": "etherscan"
+        }
+      ],
+      "services": {
+        "subgraphs": [
+          "https://api.studio.thegraph.com/deploy"
+        ]
+      },
+      "networkType": "testnet",
+      "relations": [
+        {
+          "kind": "l2Of",
+          "network": "sepolia"
+        }
+      ],
+      "issuanceRewards": false,
+      "nativeToken": "ETH",
+      "docsUrl": "https://docs.status.network",
+      "firehose": {
+        "blockType": "sf.ethereum.type.v2.Block",
+        "evmExtendedModel": true,
+        "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0x8f6889114bdfdb70c73fb33765df93a99816db0ad942bbcee71cd5d7a39e11c2",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
       }
     },
     {
@@ -1540,32 +2355,230 @@
       ],
       "apiUrls": [
         {
-          "url": "https://explorer.harmony.one/api?shard=0",
+          "url": "https://explorer.harmony.one/api",
           "kind": "etherscan"
         }
       ],
       "services": {
         "subgraphs": [
-          "https://api.thegraph.com/deploy"
+          "https://api.studio.thegraph.com/deploy"
         ]
       },
       "networkType": "mainnet",
       "issuanceRewards": false,
       "nativeToken": "ONE",
       "docsUrl": "https://docs.harmony.one",
-      "genesis": {
-        "hash": "0xb4d158b82ac8a653c42b78697ab1cd0c6a0d9a15ab3bc34130f0b719fb174d2a",
-        "height": 0
-      },
       "firehose": {
         "blockType": "sf.ethereum.type.v2.Block",
         "evmExtendedModel": false,
         "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
-        "bytesEncoding": "hex"
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0xb4d158b82ac8a653c42b78697ab1cd0c6a0d9a15ab3bc34130f0b719fb174d2a",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
       },
       "icon": {
         "web3Icons": {
           "name": "harmony"
+        }
+      }
+    },
+    {
+      "id": "blast-testnet",
+      "shortName": "Blast",
+      "secondName": "Sepolia",
+      "fullName": "Blast Sepolia Testnet",
+      "aliases": [
+        "evm-168587773",
+        "blast-sepolia"
+      ],
+      "caip2Id": "eip155:168587773",
+      "graphNode": {
+        "protocol": "ethereum"
+      },
+      "explorerUrls": [
+        "https://sepolia.blastscan.io"
+      ],
+      "rpcUrls": [
+        "https://sepolia.blast.io",
+        "https://blastsepolia.rpc.service.pinax.network"
+      ],
+      "apiUrls": [
+        {
+          "url": "https://blast-testnet.abi.pinax.network/api",
+          "kind": "etherscan"
+        },
+        {
+          "url": "https://blast-testnet.blockscout.com/api",
+          "kind": "blockscout"
+        }
+      ],
+      "services": {
+        "subgraphs": [
+          "https://api.studio.thegraph.com/deploy"
+        ],
+        "firehose": [
+          "blastsepolia.firehose.pinax.network:443"
+        ],
+        "substreams": [
+          "blastsepolia.substreams.pinax.network:443"
+        ]
+      },
+      "networkType": "testnet",
+      "relations": [
+        {
+          "kind": "l2Of",
+          "network": "sepolia"
+        },
+        {
+          "kind": "testnetOf",
+          "network": "blast-mainnet"
+        }
+      ],
+      "issuanceRewards": false,
+      "nativeToken": "ETH",
+      "docsUrl": "https://docs.blast.io",
+      "firehose": {
+        "blockType": "sf.ethereum.type.v2.Block",
+        "evmExtendedModel": false,
+        "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0x26a1c0faad7b041f34569a1bb383f00ab74b335883a44bed53e9f41ced5fd906",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
+      },
+      "icon": {
+        "web3Icons": {
+          "name": "blast"
+        }
+      }
+    },
+    {
+      "id": "mint-sepolia",
+      "shortName": "Mint",
+      "secondName": "Sepolia",
+      "fullName": "Mint Sepolia Testnet",
+      "aliases": [
+        "mint-testnet",
+        "evm-1687"
+      ],
+      "caip2Id": "eip155:1687",
+      "graphNode": {
+        "protocol": "ethereum"
+      },
+      "explorerUrls": [
+        "https://sepolia-testnet-explorer.mintchain.io"
+      ],
+      "apiUrls": [
+        {
+          "url": "https://sepolia-testnet-explorer.mintchain.io/api",
+          "kind": "etherscan"
+        }
+      ],
+      "rpcUrls": [
+        "https://sepolia-testnet-rpc.mintchain.io"
+      ],
+      "networkType": "testnet",
+      "relations": [
+        {
+          "kind": "testnetOf",
+          "network": "mint"
+        },
+        {
+          "kind": "l2Of",
+          "network": "sepolia"
+        }
+      ],
+      "services": {
+        "subgraphs": [
+          "https://api.studio.thegraph.com/deploy"
+        ]
+      },
+      "issuanceRewards": false,
+      "nativeToken": "ETH",
+      "docsUrl": "https://docs.mintchain.io",
+      "firehose": {
+        "blockType": "sf.ethereum.type.v2.Block",
+        "evmExtendedModel": true,
+        "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0xdf018ef6eb34f7f003e00e4980aee2c2af56e7a5a865924d18cc775c02190deb",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
+      },
+      "icon": {
+        "web3Icons": {
+          "name": "mint"
+        }
+      }
+    },
+    {
+      "id": "manta",
+      "shortName": "Manta",
+      "fullName": "Manta Pacific Mainnet",
+      "aliases": [
+        "evm-169",
+        "manta-mainnet"
+      ],
+      "caip2Id": "eip155:169",
+      "graphNode": {
+        "protocol": "ethereum"
+      },
+      "rpcUrls": [
+        "https://manta-pacific.drpc.org"
+      ],
+      "explorerUrls": [
+        "https://pacific-explorer.manta.network"
+      ],
+      "apiUrls": [
+        {
+          "url": "https://pacific-explorer.manta.network/api",
+          "kind": "blockscout"
+        }
+      ],
+      "services": {
+        "subgraphs": [
+          "https://api.studio.thegraph.com/deploy"
+        ]
+      },
+      "networkType": "mainnet",
+      "relations": [
+        {
+          "kind": "l2Of",
+          "network": "mainnet"
+        }
+      ],
+      "issuanceRewards": false,
+      "nativeToken": "ETH",
+      "docsUrl": "https://docs.manta.network",
+      "firehose": {
+        "blockType": "sf.ethereum.type.v2.Block",
+        "evmExtendedModel": false,
+        "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0x710b33d206fc550549c39801e9c1ca80d85399bf6e0881987e40e706c2f2f453",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
+      },
+      "icon": {
+        "web3Icons": {
+          "name": "manta-pacific"
         }
       }
     },
@@ -1594,17 +2607,23 @@
       ],
       "rpcUrls": [
         "https://ethereum-holesky-rpc.publicnode.com",
-        "https://rpc.holesky.ethpandaops.io",
-        "https://holesky.rpc.pinax.network/v1/{PINAX_API_KEY}"
+        "https://holesky.rpc.service.pinax.network"
       ],
-      "apiUrls": [],
+      "apiUrls": [
+        {
+          "url": "https://eth-holesky.blockscout.com/api",
+          "kind": "blockscout"
+        },
+        {
+          "url": "https://holesky.abi.pinax.network/api",
+          "kind": "etherscan"
+        }
+      ],
       "services": {
         "subgraphs": [
-          "https://api.thegraph.com/deploy"
+          "https://api.studio.thegraph.com/deploy"
         ],
-        "sps": [
-          "https://api.thegraph.com/deploy"
-        ],
+        "sps": [],
         "firehose": [
           "holesky.firehose.pinax.network:443",
           "holesky.eth.streamingfast.io:443"
@@ -1617,19 +2636,80 @@
       "issuanceRewards": false,
       "nativeToken": "ETH",
       "docsUrl": "https://holesky.dev",
-      "genesis": {
-        "hash": "0xb5f7f912443c940f21fd611f12828d75b534364ed9e95ca4e307729a4661bde4",
-        "height": 0
-      },
       "firehose": {
         "blockType": "sf.ethereum.type.v2.Block",
         "evmExtendedModel": true,
         "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
-        "bytesEncoding": "hex"
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0xb5f7f912443c940f21fd611f12828d75b534364ed9e95ca4e307729a4661bde4",
+          "height": 0
+        },
+        "blockFeatures": [
+          "extended"
+        ]
       },
       "icon": {
         "web3Icons": {
           "name": "ethereum"
+        }
+      }
+    },
+    {
+      "id": "hashkeychain",
+      "shortName": "Hashkey Chain",
+      "fullName": "Hashkey Chain Mainnet",
+      "aliases": [
+        "hashkeychain-mainnet",
+        "evm-177"
+      ],
+      "caip2Id": "eip155:177",
+      "graphNode": {
+        "protocol": "ethereum"
+      },
+      "explorerUrls": [
+        "https://hashkey.blockscout.com"
+      ],
+      "apiUrls": [
+        {
+          "url": "https://hashkey.blockscout.com/api",
+          "kind": "etherscan"
+        }
+      ],
+      "rpcUrls": [
+        "https://mainnet.hsk.xyz"
+      ],
+      "networkType": "mainnet",
+      "relations": [
+        {
+          "kind": "l2Of",
+          "network": "mainnet"
+        }
+      ],
+      "services": {
+        "subgraphs": [
+          "https://api.studio.thegraph.com/deploy"
+        ]
+      },
+      "issuanceRewards": false,
+      "nativeToken": "HSK",
+      "docsUrl": "https://docs.hsk.xyz",
+      "firehose": {
+        "blockType": "sf.ethereum.type.v2.Block",
+        "evmExtendedModel": false,
+        "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0xa96aea946b763641b616ce0c69f37e61d9cd0abd709ef13a6b833e67b76de208",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
+      },
+      "icon": {
+        "web3Icons": {
+          "name": "hashkey"
         }
       }
     },
@@ -1657,7 +2737,7 @@
       ],
       "rpcUrls": [
         "https://api.evm.eosnetwork.com",
-        "https://eosevm.rpc.pinax.network/v1/{PINAX_API_KEY}"
+        "https://eosevm.rpc.service.pinax.network"
       ],
       "apiUrls": [
         {
@@ -1677,15 +2757,18 @@
       "issuanceRewards": false,
       "nativeToken": "EOS",
       "docsUrl": "https://eosnetwork.com/eos-evm",
-      "genesis": {
-        "hash": "0x330402d1032bd515fa7f93b5ccb370bd1b6fdf54cdf009b6d46e55070aa0a1b8",
-        "height": 0
-      },
       "firehose": {
         "blockType": "sf.ethereum.type.v2.Block",
-        "evmExtendedModel": true,
+        "evmExtendedModel": false,
         "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
-        "bytesEncoding": "hex"
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0x330402d1032bd515fa7f93b5ccb370bd1b6fdf54cdf009b6d46e55070aa0a1b8",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
       },
       "icon": {
         "web3Icons": {
@@ -1694,13 +2777,304 @@
       }
     },
     {
-      "id": "soneium-minato",
+      "id": "mint",
+      "shortName": "Mint",
+      "fullName": "Mint Mainnet",
+      "aliases": [
+        "evm-185",
+        "mint-mainnet"
+      ],
+      "caip2Id": "eip155:185",
+      "graphNode": {
+        "protocol": "ethereum"
+      },
+      "explorerUrls": [
+        "https://explorer.mintchain.io"
+      ],
+      "rpcUrls": [
+        "https://rpc.mintchain.io"
+      ],
+      "apiUrls": [
+        {
+          "url": "https://explorer.mintchain.io/api",
+          "kind": "blockscout"
+        }
+      ],
+      "services": {
+        "subgraphs": [
+          "https://api.studio.thegraph.com/deploy"
+        ]
+      },
+      "networkType": "mainnet",
+      "relations": [
+        {
+          "kind": "l2Of",
+          "network": "mainnet"
+        }
+      ],
+      "issuanceRewards": false,
+      "nativeToken": "ETH",
+      "docsUrl": "https://docs.mintchain.io",
+      "firehose": {
+        "blockType": "sf.ethereum.type.v2.Block",
+        "evmExtendedModel": true,
+        "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0x88441835ca2344ea384e6f73e3d6f921cdd304e5bd6dca15590217e3911c61a3",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
+      },
+      "icon": {
+        "web3Icons": {
+          "name": "mint"
+        }
+      }
+    },
+    {
+      "id": "soneium",
+      "shortName": "Soneium",
+      "fullName": "Soneium Mainnet",
+      "aliases": [
+        "evm-1868",
+        "soneium-mainnet"
+      ],
+      "caip2Id": "eip155:1868",
+      "graphNode": {
+        "protocol": "ethereum"
+      },
+      "explorerUrls": [
+        "https://soneium.blockscout.com"
+      ],
+      "rpcUrls": [
+        "https://rpc.soneium.org",
+        "https://soneium.rpc.service.pinax.network"
+      ],
+      "apiUrls": [
+        {
+          "url": "https://soneium.blockscout.com/api",
+          "kind": "etherscan"
+        }
+      ],
+      "relations": [
+        {
+          "kind": "l2Of",
+          "network": "mainnet"
+        }
+      ],
+      "services": {
+        "subgraphs": [
+          "https://api.studio.thegraph.com/deploy"
+        ],
+        "firehose": [
+          "soneium.firehose.pinax.network:443"
+        ],
+        "substreams": [
+          "soneium.substreams.pinax.network:443"
+        ]
+      },
+      "networkType": "mainnet",
+      "issuanceRewards": false,
+      "nativeToken": "ETH",
+      "docsUrl": "https://soneium.org/en/docs",
+      "firehose": {
+        "blockType": "sf.ethereum.type.v2.Block",
+        "evmExtendedModel": true,
+        "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0x295d22d269634c7d0055b33b887519362d0b31899e97109d1789a8a168de1b21",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
+      },
+      "icon": {
+        "web3Icons": {
+          "name": "soneium"
+        }
+      }
+    },
+    {
+      "id": "expchain-testnet",
+      "shortName": "EXPchain",
+      "fullName": "EXPchain Testnet",
+      "aliases": [
+        "evm-18880"
+      ],
+      "caip2Id": "eip155:18880",
+      "graphNode": {
+        "protocol": "ethereum"
+      },
+      "explorerUrls": [
+        "https://blockscout-testnet.expchain.ai"
+      ],
+      "rpcUrls": [
+        "https://rpc1-testnet.expchain.ai"
+      ],
+      "apiUrls": [
+        {
+          "url": "https://blockscout-testnet.expchain.ai/api",
+          "kind": "blockscout"
+        }
+      ],
+      "services": {
+        "subgraphs": [
+          "https://api.studio.thegraph.com/deploy"
+        ]
+      },
+      "networkType": "testnet",
+      "relations": [],
+      "issuanceRewards": false,
+      "nativeToken": "tZKJ",
+      "docsUrl": "https://docs.polyhedra.network/expchain",
+      "firehose": {
+        "blockType": "sf.ethereum.type.v2.Block",
+        "evmExtendedModel": false,
+        "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0xcd32fbe4844c34d8c24a50949e84a2b67bacca64a1229f248bb4c8a95c5feb75",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
+      },
+      "icon": {
+        "web3Icons": {
+          "name": "expchain"
+        }
+      }
+    },
+    {
+      "id": "swellchain",
+      "shortName": "Swellchain",
+      "fullName": "Swellchain Mainnet",
+      "aliases": [
+        "evm-1923",
+        "swellchain-mainnet"
+      ],
+      "caip2Id": "eip155:1923",
+      "graphNode": {
+        "protocol": "ethereum"
+      },
+      "explorerUrls": [
+        "https://explorer.swellnetwork.io"
+      ],
+      "rpcUrls": [
+        "https://rpc.ankr.com/swell"
+      ],
+      "apiUrls": [
+        {
+          "url": "https://explorer.swellnetwork.io/api",
+          "kind": "blockscout"
+        }
+      ],
+      "services": {
+        "subgraphs": [
+          "https://api.studio.thegraph.com/deploy"
+        ]
+      },
+      "networkType": "mainnet",
+      "issuanceRewards": false,
+      "nativeToken": "ETH",
+      "docsUrl": "https://docs.swellnetwork.io",
+      "firehose": {
+        "blockType": "sf.ethereum.type.v2.Block",
+        "evmExtendedModel": true,
+        "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0x92379973a1576876b7337a9ce89e2a7a9cb99887f55e6045ed2069d5d98d9319",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
+      },
+      "icon": {
+        "web3Icons": {
+          "name": "swell"
+        }
+      }
+    },
+    {
+      "id": "swellchain-sepolia",
+      "shortName": "Swellchain",
+      "secondName": "Sepolia",
+      "fullName": "Swellchain Sepolia Testnet",
+      "aliases": [
+        "swellchain-testnet",
+        "evm-1924"
+      ],
+      "caip2Id": "eip155:1924",
+      "graphNode": {
+        "protocol": "ethereum"
+      },
+      "explorerUrls": [
+        "https://swell-testnet-explorer.alt.technology"
+      ],
+      "apiUrls": [
+        {
+          "url": "https://swell-testnet-explorer.alt.technology/api",
+          "kind": "blockscout"
+        }
+      ],
+      "rpcUrls": [
+        "https://rpc.ankr.com/swell_sepolia"
+      ],
+      "networkType": "testnet",
+      "relations": [
+        {
+          "kind": "testnetOf",
+          "network": "swellchain"
+        },
+        {
+          "kind": "l2Of",
+          "network": "sepolia"
+        }
+      ],
+      "services": {
+        "subgraphs": [
+          "https://api.studio.thegraph.com/deploy"
+        ]
+      },
+      "issuanceRewards": false,
+      "nativeToken": "ETH",
+      "docsUrl": "https://docs.swellnetwork.io",
+      "firehose": {
+        "blockType": "sf.ethereum.type.v2.Block",
+        "evmExtendedModel": true,
+        "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0x56d83858e4fab3bcd009c0014c91fce910f0e4585d1f446e043c813043fd0317",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
+      },
+      "icon": {
+        "web3Icons": {
+          "name": "swell"
+        }
+      }
+    },
+    {
+      "id": "soneium-testnet",
       "shortName": "Soneium",
       "secondName": "Minato",
       "fullName": "Soneium Minato Testnet",
       "aliases": [
         "soneium-minato-testnet",
-        "soneium-testnet"
+        "soneium-minato",
+        "minato"
       ],
       "caip2Id": "eip155:1946",
       "graphNode": {
@@ -1711,11 +3085,15 @@
       ],
       "rpcUrls": [
         "https://rpc.minato.soneium.org",
-        "https://minato.rpc.pinax.network/v1/{PINAX_API_KEY}"
+        "https://minato.rpc.service.pinax.network"
       ],
       "apiUrls": [
         {
           "url": "https://soneium-minato.blockscout.com/api",
+          "kind": "etherscan"
+        },
+        {
+          "url": "https://api.routescan.io/v2/network/testnet/evm/1946/etherscan/api",
           "kind": "etherscan"
         }
       ],
@@ -1723,7 +3101,7 @@
       "relations": [
         {
           "kind": "testnetOf",
-          "network": "soneium-minato"
+          "network": "soneium"
         },
         {
           "kind": "l2Of",
@@ -1732,11 +3110,9 @@
       ],
       "services": {
         "subgraphs": [
-          "https://api.thegraph.com/deploy"
+          "https://api.studio.thegraph.com/deploy"
         ],
-        "sps": [
-          "https://api.thegraph.com/deploy"
-        ],
+        "sps": [],
         "firehose": [
           "minato.firehose.pinax.network:443"
         ],
@@ -1747,15 +3123,18 @@
       "issuanceRewards": false,
       "nativeToken": "ETH",
       "docsUrl": "https://soneium.org/en/docs",
-      "genesis": {
-        "hash": "0x7ec49d93fa8f47c00e98cc5965cd3903a8faa9238743d2eba0e0550ab4c45c43",
-        "height": 0
-      },
       "firehose": {
         "blockType": "sf.ethereum.type.v2.Block",
-        "evmExtendedModel": false,
+        "evmExtendedModel": true,
         "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
-        "bytesEncoding": "hex"
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0x7ec49d93fa8f47c00e98cc5965cd3903a8faa9238743d2eba0e0550ab4c45c43",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
       },
       "icon": {
         "web3Icons": {
@@ -1779,12 +3158,19 @@
         "https://www.oklink.com/xlayer-test"
       ],
       "rpcUrls": [
-        "https://testrpc.xlayer.tech"
+        "https://testrpc.xlayer.tech",
+        "https://xlayertestrpc.okx.com",
+        "https://xlayertest.rpc.service.pinax.network"
       ],
-      "apiUrls": [],
       "services": {
         "subgraphs": [
-          "https://api.thegraph.com/deploy"
+          "https://api.studio.thegraph.com/deploy"
+        ],
+        "firehose": [
+          "xlayertest.firehose.pinax.network:443"
+        ],
+        "substreams": [
+          "xlayertest.substreams.pinax.network:443"
         ]
       },
       "networkType": "testnet",
@@ -1801,15 +3187,18 @@
       "issuanceRewards": false,
       "nativeToken": "OKB",
       "docsUrl": "https://www.okx.com/xlayer",
-      "genesis": {
-        "hash": "0x22a8085892b367833bd7431fa5a90ff6b5d3769167cdaa29ce8571d07bc8f866",
-        "height": 0
-      },
       "firehose": {
         "blockType": "sf.ethereum.type.v2.Block",
         "evmExtendedModel": false,
         "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
-        "bytesEncoding": "hex"
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0x22a8085892b367833bd7431fa5a90ff6b5d3769167cdaa29ce8571d07bc8f866",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
       },
       "icon": {
         "web3Icons": {
@@ -1834,12 +3223,12 @@
       ],
       "rpcUrls": [
         "https://rpc.xlayer.tech",
-        "https://xlayer.rpc.pinax.network/v1/{PINAX_API_KEY}"
+        "https://xlayerrpc.okx.com",
+        "https://xlayer.rpc.service.pinax.network"
       ],
-      "apiUrls": [],
       "services": {
         "subgraphs": [
-          "https://api.thegraph.com/deploy"
+          "https://api.studio.thegraph.com/deploy"
         ],
         "firehose": [
           "xlayer.firehose.pinax.network:443"
@@ -1858,19 +3247,82 @@
       "issuanceRewards": false,
       "nativeToken": "OKB",
       "docsUrl": "https://www.okx.com/xlayer",
-      "genesis": {
-        "hash": "0x11f32f605beb94a1acb783cb3b6da6d7975461ce3addf441e7ad60c2ec95e88f",
-        "height": 0
-      },
       "firehose": {
         "blockType": "sf.ethereum.type.v2.Block",
         "evmExtendedModel": false,
         "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
-        "bytesEncoding": "hex"
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0x11f32f605beb94a1acb783cb3b6da6d7975461ce3addf441e7ad60c2ec95e88f",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
       },
       "icon": {
         "web3Icons": {
           "name": "x-layer"
+        }
+      }
+    },
+    {
+      "id": "ronin",
+      "shortName": "Ronin",
+      "fullName": "Ronin Mainnet",
+      "aliases": [
+        "evm-2020",
+        "ronin-mainnet"
+      ],
+      "caip2Id": "eip155:2020",
+      "graphNode": {
+        "protocol": "ethereum"
+      },
+      "services": {
+        "subgraphs": [
+          "https://api.studio.thegraph.com/deploy"
+        ],
+        "firehose": [
+          "ronin.firehose.pinax.network:443"
+        ],
+        "substreams": [
+          "ronin.substreams.pinax.network:443"
+        ]
+      },
+      "networkType": "mainnet",
+      "relations": [],
+      "explorerUrls": [
+        "https://app.roninchain.com"
+      ],
+      "rpcUrls": [
+        "https://api.roninchain.com/rpc",
+        "https://ronin.rpc.service.pinax.network"
+      ],
+      "issuanceRewards": false,
+      "nativeToken": "RON",
+      "docsUrl": "https://docs.roninchain.com",
+      "indexerDocsUrls": [
+        {
+          "url": "https://docs.infradao.com/archive-nodes-101/ronin",
+          "description": "Archive Nodes 101"
+        }
+      ],
+      "firehose": {
+        "blockType": "sf.ethereum.type.v2.Block",
+        "evmExtendedModel": false,
+        "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0x6e675ee97607f4e695188786c3c1853fb1562f1c075629eb5dbcff269422a1a4",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
+      },
+      "icon": {
+        "web3Icons": {
+          "name": "ronin"
         }
       }
     },
@@ -1881,7 +3333,8 @@
       "aliases": [
         "evm-204",
         "opbnb",
-        "bsc-op"
+        "bsc-op",
+        "bnb-op-mainnet"
       ],
       "caip2Id": "eip155:204",
       "graphNode": {
@@ -1898,9 +3351,14 @@
       ],
       "rpcUrls": [
         "https://opbnb-mainnet-rpc.bnbchain.org",
-        "https://opbnb.rpc.pinax.network/v1/{PINAX_API_KEY}"
+        "https://opbnb.rpc.service.pinax.network"
       ],
-      "apiUrls": [],
+      "apiUrls": [
+        {
+          "url": "https://bnb-op.abi.pinax.network/api",
+          "kind": "etherscan"
+        }
+      ],
       "services": {
         "firehose": [
           "opbnb.firehose.pinax.network:443"
@@ -1913,15 +3371,18 @@
       "issuanceRewards": false,
       "nativeToken": "BNB",
       "docsUrl": "https://docs.bnbchain.org/bnb-opbnb",
-      "genesis": {
-        "hash": "0x4dd61178c8b0f01670c231597e7bcb368e84545acd46d940a896d6a791dd6df4",
-        "height": 0
-      },
       "firehose": {
         "blockType": "sf.ethereum.type.v2.Block",
         "evmExtendedModel": false,
         "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
-        "bytesEncoding": "hex"
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0x4dd61178c8b0f01670c231597e7bcb368e84545acd46d940a896d6a791dd6df4",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
       },
       "icon": {
         "web3Icons": {
@@ -1930,40 +3391,97 @@
       }
     },
     {
-      "id": "blast-testnet",
-      "shortName": "Blast",
-      "secondName": "Sepolia",
-      "fullName": "Blast Sepolia Testnet",
+      "id": "corn",
+      "shortName": "Corn",
+      "fullName": "Corn Maizenet",
       "aliases": [
-        "evm-23888",
-        "blast-sepolia"
+        "corn-maizenet",
+        "corn-mainnet"
       ],
-      "caip2Id": "eip155:23888",
+      "caip2Id": "eip155:21000000",
       "graphNode": {
         "protocol": "ethereum"
       },
       "explorerUrls": [
-        "https://sepolia.blastscan.io"
+        "https://maizenet-explorer.usecorn.com"
       ],
       "rpcUrls": [
-        "https://sepolia.blast.io",
-        "https://blastsepolia.rpc.pinax.network/v1/{PINAX_API_KEY}"
+        "https://maizenet-rpc.usecorn.com"
       ],
       "apiUrls": [
         {
-          "url": "https://blast-testnet.abi.pinax.network/api",
+          "url": "https://maizenet-explorer.usecorn.com/api",
+          "kind": "etherscan"
+        },
+        {
+          "url": "https://api.routescan.io/v2/network/mainnet/evm/21000000/etherscan/api",
           "kind": "etherscan"
         }
       ],
       "services": {
         "subgraphs": [
-          "https://api.thegraph.com/deploy"
-        ],
-        "firehose": [
-          "blastsepolia.firehose.pinax.network:443"
-        ],
-        "substreams": [
-          "blastsepolia.substreams.pinax.network:443"
+          "https://api.studio.thegraph.com/deploy"
+        ]
+      },
+      "networkType": "mainnet",
+      "relations": [
+        {
+          "kind": "l2Of",
+          "network": "mainnet"
+        }
+      ],
+      "issuanceRewards": false,
+      "nativeToken": "BTCN",
+      "docsUrl": "https://docs.usecorn.com",
+      "firehose": {
+        "blockType": "sf.ethereum.type.v2.Block",
+        "evmExtendedModel": false,
+        "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0x80cd408e666fa2755da953bfd9056f09618318d5f71011a8247cebe2a13ae30f",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
+      },
+      "icon": {
+        "web3Icons": {
+          "name": "corn"
+        }
+      }
+    },
+    {
+      "id": "corn-testnet",
+      "shortName": "Corn",
+      "fullName": "Corn Testnet",
+      "aliases": [
+        "corn-sepolia"
+      ],
+      "caip2Id": "eip155:21000001",
+      "graphNode": {
+        "protocol": "ethereum"
+      },
+      "explorerUrls": [
+        "https://testnet-explorer.usecorn.com"
+      ],
+      "rpcUrls": [
+        "https://testnet-rpc.usecorn.com"
+      ],
+      "apiUrls": [
+        {
+          "url": "https://testnet-explorer.usecorn.com/api",
+          "kind": "etherscan"
+        },
+        {
+          "url": "https://api.routescan.io/v2/network/testnet/evm/21000001/etherscan/api",
+          "kind": "etherscan"
+        }
+      ],
+      "services": {
+        "subgraphs": [
+          "https://api.studio.thegraph.com/deploy"
         ]
       },
       "networkType": "testnet",
@@ -1974,32 +3492,202 @@
         },
         {
           "kind": "testnetOf",
-          "network": "blast-mainnet"
+          "network": "corn"
         }
       ],
       "issuanceRewards": false,
-      "nativeToken": "ETH",
-      "docsUrl": "https://docs.blast.io",
-      "genesis": {
-        "hash": "0x26a1c0faad7b041f34569a1bb383f00ab74b335883a44bed53e9f41ced5fd906",
-        "height": 0
-      },
+      "nativeToken": "BTCN",
+      "docsUrl": "https://docs.usecorn.com",
       "firehose": {
         "blockType": "sf.ethereum.type.v2.Block",
         "evmExtendedModel": false,
         "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
-        "bytesEncoding": "hex"
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0x110954744ffd9d4bcd4f7998896d1948f654c9e5ccf6fcda1637a35a1863a71d",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
       },
       "icon": {
         "web3Icons": {
-          "name": "blast"
+          "name": "corn"
+        }
+      }
+    },
+    {
+      "id": "kava",
+      "shortName": "Kava",
+      "fullName": "Kava Mainnet",
+      "aliases": [
+        "kava-mainnet",
+        "evm-2222"
+      ],
+      "caip2Id": "eip155:2222",
+      "graphNode": {
+        "protocol": "ethereum"
+      },
+      "explorerUrls": [
+        "https://kavascan.io"
+      ],
+      "rpcUrls": [
+        "https://rpc.ankr.com/kava_evm",
+        "https://kava.rpc.service.pinax.network"
+      ],
+      "networkType": "mainnet",
+      "services": {},
+      "issuanceRewards": false,
+      "nativeToken": "KAVA",
+      "docsUrl": "https://docs.kava.io",
+      "firehose": {
+        "blockType": "sf.ethereum.type.v2.Block",
+        "evmExtendedModel": false,
+        "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0x9d2af876309bb9174604004a813dcfee94f4947b08c5bb4c1a042f318488851e",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
+      },
+      "icon": {
+        "web3Icons": {
+          "name": "kava"
+        }
+      }
+    },
+    {
+      "id": "lens",
+      "shortName": "Lens",
+      "fullName": "Lens Mainnet",
+      "aliases": [
+        "evm-232",
+        "lens-mainnet"
+      ],
+      "caip2Id": "eip155:232",
+      "graphNode": {
+        "protocol": "ethereum"
+      },
+      "explorerUrls": [
+        "https://explorer.lens.xyz"
+      ],
+      "apiUrls": [
+        {
+          "url": "https://explorer-api.lens.xyz/api",
+          "kind": "etherscan"
+        }
+      ],
+      "rpcUrls": [
+        "https://rpc.lens.dev"
+      ],
+      "services": {
+        "subgraphs": [
+          "https://api.studio.thegraph.com/deploy"
+        ]
+      },
+      "networkType": "mainnet",
+      "relations": [
+        {
+          "kind": "l2Of",
+          "network": "mainnet"
+        }
+      ],
+      "issuanceRewards": false,
+      "nativeToken": "GHO",
+      "docsUrl": "https://lens.xyz/docs",
+      "firehose": {
+        "blockType": "sf.ethereum.type.v2.Block",
+        "evmExtendedModel": false,
+        "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0xe8e77626586f73b955364c7b4bbf0bb7f7685ebd40e852b164633a4acbd3244c",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
+      },
+      "icon": {
+        "web3Icons": {
+          "name": "lens"
+        }
+      }
+    },
+    {
+      "id": "polygon-zkevm-cardona",
+      "shortName": "Polygon zkEVM",
+      "secondName": "Cardona",
+      "fullName": "Polygon zkEVM Cardona Testnet",
+      "aliases": [
+        "polygon-cardona"
+      ],
+      "caip2Id": "eip155:2442",
+      "graphNode": {
+        "protocol": "ethereum"
+      },
+      "relations": [
+        {
+          "kind": "l2Of",
+          "network": "sepolia"
+        },
+        {
+          "kind": "testnetOf",
+          "network": "polygon-zkevm"
+        }
+      ],
+      "explorerUrls": [
+        "https://cardona-zkevm.polygonscan.com"
+      ],
+      "rpcUrls": [
+        "https://rpc.cardona.zkevm-rpc.com",
+        "https://cardona.rpc.service.pinax.network"
+      ],
+      "apiUrls": [
+        {
+          "url": "https://polygon-zkevm-cardona.abi.pinax.network/api",
+          "kind": "etherscan"
+        }
+      ],
+      "networkType": "testnet",
+      "services": {
+        "firehose": [
+          "cardona.firehose.pinax.network:443"
+        ],
+        "substreams": [
+          "cardona.substreams.pinax.network:443"
+        ]
+      },
+      "issuanceRewards": false,
+      "nativeToken": "ETH",
+      "docsUrl": "https://docs.polygon.technology/zkEVM",
+      "firehose": {
+        "blockType": "sf.ethereum.type.v2.Block",
+        "evmExtendedModel": false,
+        "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0x676c1a76a6c5855a32bdf7c61977a0d1510088a4eeac1330466453b3d08b60b9",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
+      },
+      "icon": {
+        "web3Icons": {
+          "name": "polygon-zkevm"
         }
       }
     },
     {
       "id": "cronos",
       "shortName": "Cronos",
-      "fullName": "Cronos Mainnet",
+      "fullName": "Cronos EVM Chain Mainnet",
       "aliases": [
         "evm-25",
         "cronos-mainnet"
@@ -2013,28 +3701,39 @@
       ],
       "rpcUrls": [
         "https://evm.cronos.org",
-        "https://cronos.rpc.pinax.network/v1/{PINAX_API_KEY}"
+        "https://cronos.rpc.service.pinax.network"
       ],
       "apiUrls": [
         {
-          "url": "https://explorer-api.cronos.org/mainnet/api/v1",
-          "kind": "other"
+          "url": "https://cronos.org/explorer/api",
+          "kind": "blockscout"
+        },
+        {
+          "url": "https://cronos.abi.pinax.network/api",
+          "kind": "etherscan"
         }
       ],
-      "services": {},
+      "services": {
+        "subgraphs": [
+          "https://api.studio.thegraph.com/deploy"
+        ]
+      },
       "networkType": "mainnet",
       "issuanceRewards": false,
       "nativeToken": "CRO",
       "docsUrl": "https://docs.cronos.org",
-      "genesis": {
-        "hash": "0xa7f4e603aa51239a15e0a3fafb15c6e4c6d6f2c39c55770330efd2fa5afc12a9",
-        "height": 0
-      },
       "firehose": {
         "blockType": "sf.ethereum.type.v2.Block",
         "evmExtendedModel": false,
         "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
-        "bytesEncoding": "hex"
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0xa7f4e603aa51239a15e0a3fafb15c6e4c6d6f2c39c55770330efd2fa5afc12a9",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
       },
       "icon": {
         "web3Icons": {
@@ -2061,7 +3760,7 @@
       ],
       "rpcUrls": [
         "https://rpc.ftm.tools",
-        "https://fantom.rpc.pinax.network/v1/{PINAX_API_KEY}"
+        "https://fantom.rpc.service.pinax.network"
       ],
       "apiUrls": [
         {
@@ -2071,7 +3770,7 @@
       ],
       "services": {
         "subgraphs": [
-          "https://api.thegraph.com/deploy"
+          "https://api.studio.thegraph.com/deploy"
         ],
         "firehose": [
           "fantom.firehose.pinax.network:443"
@@ -2087,22 +3786,145 @@
       "indexerDocsUrls": [
         {
           "url": "https://docs.infradao.com/archive-nodes-101/fantom",
-          "description": "Arhchive Nodes 101"
+          "description": "Archive Nodes 101"
         }
       ],
-      "genesis": {
-        "hash": "0x0000000000000000c20dbfb2ec18ae20037c716f3ba2d9e1da768a9deca17cb4",
-        "height": 0
-      },
       "firehose": {
         "blockType": "sf.ethereum.type.v2.Block",
         "evmExtendedModel": false,
         "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
-        "bytesEncoding": "hex"
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0x0000000000000000c20dbfb2ec18ae20037c716f3ba2d9e1da768a9deca17cb4",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
       },
       "icon": {
         "web3Icons": {
           "name": "fantom"
+        }
+      }
+    },
+    {
+      "id": "fraxtal",
+      "shortName": "Fraxtal",
+      "fullName": "Fraxtal Mainnet",
+      "aliases": [
+        "evm-252",
+        "fraxtal-mainnet"
+      ],
+      "caip2Id": "eip155:252",
+      "graphNode": {
+        "protocol": "ethereum"
+      },
+      "explorerUrls": [
+        "https://fraxscan.com"
+      ],
+      "rpcUrls": [
+        "https://rpc.frax.com"
+      ],
+      "apiUrls": [
+        {
+          "url": "https://fraxtal.abi.pinax.network/api",
+          "kind": "etherscan"
+        },
+        {
+          "url": "https://api.routescan.io/v2/network/mainnet/evm/252/etherscan/api",
+          "kind": "etherscan"
+        }
+      ],
+      "services": {
+        "subgraphs": [
+          "https://api.studio.thegraph.com/deploy"
+        ]
+      },
+      "networkType": "mainnet",
+      "relations": [
+        {
+          "kind": "l2Of",
+          "network": "mainnet"
+        }
+      ],
+      "issuanceRewards": false,
+      "nativeToken": "frxETH",
+      "docsUrl": "https://docs.mintchain.io",
+      "firehose": {
+        "blockType": "sf.ethereum.type.v2.Block",
+        "evmExtendedModel": true,
+        "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0x521982bd54239dc71269eefb58601762cc15cfb2978e0becb46af7962ed6bfaa",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
+      },
+      "icon": {
+        "web3Icons": {
+          "name": "fraxtal"
+        }
+      }
+    },
+    {
+      "id": "abstract",
+      "shortName": "Abstract",
+      "fullName": "Abstract Mainnet",
+      "aliases": [
+        "evm-2741",
+        "abstract-mainnet"
+      ],
+      "caip2Id": "eip155:2741",
+      "graphNode": {
+        "protocol": "ethereum"
+      },
+      "rpcUrls": [
+        "https://api.mainnet.abs.xyz"
+      ],
+      "explorerUrls": [
+        "https://abscan.org"
+      ],
+      "apiUrls": [
+        {
+          "url": "https://abstract.abi.pinax.network/api",
+          "kind": "etherscan"
+        }
+      ],
+      "services": {
+        "subgraphs": [
+          "https://api.studio.thegraph.com/deploy"
+        ]
+      },
+      "networkType": "mainnet",
+      "relations": [
+        {
+          "kind": "l2Of",
+          "network": "mainnet"
+        }
+      ],
+      "issuanceRewards": false,
+      "nativeToken": "ETH",
+      "docsUrl": "https://docs.abs.xyz",
+      "firehose": {
+        "blockType": "sf.ethereum.type.v2.Block",
+        "evmExtendedModel": false,
+        "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0xe8e77626586f73b955364c7b4bbf0bb7f7685ebd40e852b164633a4acbd3244c",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
+      },
+      "icon": {
+        "web3Icons": {
+          "name": "abstract"
         }
       }
     },
@@ -2123,7 +3945,7 @@
       ],
       "rpcUrls": [
         "https://mainnet.boba.network",
-        "https://boba.rpc.pinax.network/v1/{PINAX_API_KEY}"
+        "https://boba.rpc.service.pinax.network"
       ],
       "apiUrls": [
         {
@@ -2133,7 +3955,7 @@
       ],
       "services": {
         "subgraphs": [
-          "https://api.thegraph.com/deploy"
+          "https://api.studio.thegraph.com/deploy"
         ],
         "firehose": [
           "boba.firehose.pinax.network:443"
@@ -2155,18 +3977,21 @@
       "indexerDocsUrls": [
         {
           "url": "https://docs.infradao.com/archive-nodes-101/boba",
-          "description": "Arhchive Nodes 101"
+          "description": "Archive Nodes 101"
         }
       ],
-      "genesis": {
-        "hash": "0xdcd9e6a8f9973eaa62da2874959cb152faeb4fd6929177bd6335a1a16074ef9c",
-        "height": 0
-      },
       "firehose": {
         "blockType": "sf.ethereum.type.v2.Block",
         "evmExtendedModel": false,
         "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
-        "bytesEncoding": "hex"
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0xdcd9e6a8f9973eaa62da2874959cb152faeb4fd6929177bd6335a1a16074ef9c",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
       },
       "icon": {
         "web3Icons": {
@@ -2191,7 +4016,7 @@
       ],
       "rpcUrls": [
         "https://sepolia.boba.network",
-        "https://bobasepolia.rpc.pinax.network/v1/{PINAX_API_KEY}"
+        "https://bobasepolia.rpc.service.pinax.network"
       ],
       "apiUrls": [
         {
@@ -2201,7 +4026,7 @@
       ],
       "services": {
         "subgraphs": [
-          "https://api.thegraph.com/deploy"
+          "https://api.studio.thegraph.com/deploy"
         ],
         "firehose": [
           "bobasepolia.firehose.pinax.network:443"
@@ -2224,15 +4049,18 @@
       "issuanceRewards": false,
       "nativeToken": "ETH",
       "docsUrl": "https://docs.boba.network",
-      "genesis": {
-        "hash": "0xc6171953a6a376ece6e33149686044f24f58a387ce2636a54e391d330b2326b5",
-        "height": 0
-      },
       "firehose": {
         "blockType": "sf.ethereum.type.v2.Block",
         "evmExtendedModel": false,
         "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
-        "bytesEncoding": "hex"
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0xc6171953a6a376ece6e33149686044f24f58a387ce2636a54e391d330b2326b5",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
       },
       "icon": {
         "web3Icons": {
@@ -2255,38 +4083,42 @@
         "https://rootstock.blockscout.com"
       ],
       "rpcUrls": [
-        "https://public-node.rsk.co"
+        "https://public-node.rsk.co",
+        "https://rootstock.rpc.service.pinax.network"
       ],
       "apiUrls": [
         {
           "url": "https://rootstock.blockscout.com/api",
-          "kind": "etherscan"
+          "kind": "blockscout"
         }
       ],
       "services": {
         "subgraphs": [
-          "https://api.thegraph.com/deploy"
+          "https://api.studio.thegraph.com/deploy"
         ]
       },
       "networkType": "mainnet",
-      "issuanceRewards": false,
+      "issuanceRewards": true,
       "nativeToken": "RBTC",
       "docsUrl": "https://dev.rootstock.io",
       "indexerDocsUrls": [
         {
           "url": "https://docs.infradao.com/archive-nodes-101/rootstock",
-          "description": "Arhchive Nodes 101"
+          "description": "Archive Nodes 101"
         }
       ],
-      "genesis": {
-        "hash": "0xf88529d4ab262c0f4d042e9d8d3f2472848eaafe1a9b7213f57617eb40a9f9e0",
-        "height": 0
-      },
       "firehose": {
         "blockType": "sf.ethereum.type.v2.Block",
         "evmExtendedModel": false,
         "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
-        "bytesEncoding": "hex"
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0xf88529d4ab262c0f4d042e9d8d3f2472848eaafe1a9b7213f57617eb40a9f9e0",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
       },
       "icon": {
         "web3Icons": {
@@ -2318,11 +4150,19 @@
         {
           "url": "https://block-explorer-api.sepolia.zksync.dev/api",
           "kind": "etherscan"
+        },
+        {
+          "url": "https://zksync-sepolia.blockscout.com/api",
+          "kind": "blockscout"
+        },
+        {
+          "url": "https://zksync-era-sepolia.abi.pinax.network/api",
+          "kind": "etherscan"
         }
       ],
       "services": {
         "subgraphs": [
-          "https://api.thegraph.com/deploy"
+          "https://api.studio.thegraph.com/deploy"
         ]
       },
       "networkType": "testnet",
@@ -2339,15 +4179,18 @@
       "issuanceRewards": false,
       "nativeToken": "ETH",
       "docsUrl": "https://docs.zksync.io",
-      "genesis": {
-        "hash": "0x086227fafad2bc4d08a122ebb690d958edcd43352d38d31646968480f496827c",
-        "height": 1
-      },
       "firehose": {
         "blockType": "sf.ethereum.type.v2.Block",
         "evmExtendedModel": false,
         "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
-        "bytesEncoding": "hex"
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0xe8e77626586f73b955364c7b4bbf0bb7f7685ebd40e852b164633a4acbd3244c",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
       },
       "icon": {
         "web3Icons": {
@@ -2378,7 +4221,7 @@
       ],
       "services": {
         "subgraphs": [
-          "https://api.thegraph.com/deploy"
+          "https://api.studio.thegraph.com/deploy"
         ]
       },
       "networkType": "testnet",
@@ -2391,19 +4234,78 @@
       "issuanceRewards": false,
       "nativeToken": "tRBTC",
       "docsUrl": "https://dev.rootstock.io",
-      "genesis": {
-        "hash": "0xcabb7fbe88cd6d922042a32ffc08ce8b1fbb37d650b9d4e7dbfe2a7469adfa42",
-        "height": 0
-      },
       "firehose": {
         "blockType": "sf.ethereum.type.v2.Block",
         "evmExtendedModel": false,
         "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
-        "bytesEncoding": "hex"
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0xcabb7fbe88cd6d922042a32ffc08ce8b1fbb37d650b9d4e7dbfe2a7469adfa42",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
       },
       "icon": {
         "web3Icons": {
           "name": "rootstock"
+        }
+      }
+    },
+    {
+      "id": "ozean-poseidon",
+      "shortName": "Ozean",
+      "fullName": "Ozean Poseidon Testnet",
+      "aliases": [
+        "evm-31911"
+      ],
+      "caip2Id": "eip155:31911",
+      "graphNode": {
+        "protocol": "ethereum"
+      },
+      "explorerUrls": [
+        "https://poseidon-testnet.explorer.caldera.xyz"
+      ],
+      "rpcUrls": [
+        "https://poseidon-testnet.rpc.caldera.xyz/http"
+      ],
+      "apiUrls": [
+        {
+          "url": "https://poseidon-testnet.explorer.caldera.xyz/api",
+          "kind": "etherscan"
+        }
+      ],
+      "services": {
+        "subgraphs": [
+          "https://api.studio.thegraph.com/deploy"
+        ]
+      },
+      "networkType": "testnet",
+      "relations": [
+        {
+          "kind": "l2Of",
+          "network": "sepolia"
+        }
+      ],
+      "issuanceRewards": false,
+      "nativeToken": "ETH",
+      "firehose": {
+        "blockType": "sf.ethereum.type.v2.Block",
+        "evmExtendedModel": false,
+        "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0x7ee9e9a8b75fa5f73e276e4b7f9eee22ceac26ec7516141a4ee737be1881102c",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
+      },
+      "icon": {
+        "web3Icons": {
+          "name": "ozean"
         }
       }
     },
@@ -2414,7 +4316,8 @@
       "fullName": "zkSync Mainnet",
       "aliases": [
         "evm-324",
-        "zksync"
+        "zksync",
+        "zksync-era-mainnet"
       ],
       "caip2Id": "eip155:324",
       "graphNode": {
@@ -2424,17 +4327,32 @@
         "https://explorer.zksync.io"
       ],
       "rpcUrls": [
-        "https://mainnet.era.zksync.io"
+        "https://mainnet.era.zksync.io",
+        "https://zksyncera.rpc.service.pinax.network"
       ],
       "apiUrls": [
         {
           "url": "https://block-explorer-api.mainnet.zksync.io/api",
           "kind": "etherscan"
+        },
+        {
+          "url": "https://zksync.blockscout.com/api",
+          "kind": "blockscout"
+        },
+        {
+          "url": "https://zksync-era.abi.pinax.network/api",
+          "kind": "etherscan"
         }
       ],
       "services": {
         "subgraphs": [
-          "https://api.thegraph.com/deploy"
+          "https://api.studio.thegraph.com/deploy"
+        ],
+        "firehose": [
+          "zksyncera.firehose.pinax.network:443"
+        ],
+        "substreams": [
+          "zksyncera.substreams.pinax.network:443"
         ]
       },
       "networkType": "mainnet",
@@ -2444,22 +4362,235 @@
           "network": "mainnet"
         }
       ],
-      "issuanceRewards": false,
+      "issuanceRewards": true,
       "nativeToken": "ETH",
       "docsUrl": "https://docs.zksync.io",
-      "genesis": {
-        "hash": "0x51f81bcdfc324a0dff2b5bec9d92e21cbebc4d5e29d3a3d30de3e03fbeab8d7f",
-        "height": 1
-      },
+      "indexerDocsUrls": [
+        {
+          "url": "https://docs.infradao.com/archive-nodes-101/zksync-era",
+          "description": "Archive Nodes 101"
+        }
+      ],
       "firehose": {
         "blockType": "sf.ethereum.type.v2.Block",
         "evmExtendedModel": false,
         "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
-        "bytesEncoding": "hex"
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0xe8e77626586f73b955364c7b4bbf0bb7f7685ebd40e852b164633a4acbd3244c",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
       },
       "icon": {
         "web3Icons": {
           "name": "zksync"
+        }
+      }
+    },
+    {
+      "id": "zilliqa-protomainnet",
+      "shortName": "Zilliqa",
+      "secondName": "Proto-Mainnet",
+      "fullName": "Zilliqa 2.0 Proto-Mainnet",
+      "aliases": [
+        "evm-32770"
+      ],
+      "caip2Id": "eip155:32770",
+      "graphNode": {
+        "protocol": "ethereum"
+      },
+      "explorerUrls": [
+        "https://explorer.zq2-protomainnet.zilliqa.com"
+      ],
+      "networkType": "testnet",
+      "services": {
+        "subgraphs": [
+          "https://api.studio.thegraph.com/deploy"
+        ]
+      },
+      "issuanceRewards": false,
+      "nativeToken": "ZIL",
+      "docsUrl": "https://dev.zilliqa.com",
+      "firehose": {
+        "blockType": "sf.ethereum.type.v2.Block",
+        "evmExtendedModel": false,
+        "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0xaef57e820056b14dbb42e4b39d38587f727d5a7014039c44018e16db7bb05eb4",
+          "height": 3
+        },
+        "blockFeatures": [
+          "base"
+        ]
+      },
+      "icon": {
+        "web3Icons": {
+          "name": "zilliqa"
+        }
+      }
+    },
+    {
+      "id": "apechain-curtis",
+      "shortName": "ApeChain",
+      "secondName": "Curtis",
+      "fullName": "ApeChain Curtis Testnet",
+      "aliases": [
+        "apechain-testnet",
+        "evm-33111"
+      ],
+      "caip2Id": "eip155:33111",
+      "graphNode": {
+        "protocol": "ethereum"
+      },
+      "explorerUrls": [
+        "https://curtis.apescan.io"
+      ],
+      "rpcUrls": [
+        "https://curtis.rpc.caldera.xyz/http"
+      ],
+      "apiUrls": [
+        {
+          "url": "https://apechain-testnet.abi.pinax.network/api",
+          "kind": "etherscan"
+        }
+      ],
+      "networkType": "testnet",
+      "relations": [
+        {
+          "kind": "testnetOf",
+          "network": "apechain"
+        },
+        {
+          "kind": "l2Of",
+          "network": "arbitrum-sepolia"
+        }
+      ],
+      "services": {
+        "subgraphs": [
+          "https://api.studio.thegraph.com/deploy"
+        ]
+      },
+      "issuanceRewards": false,
+      "nativeToken": "APE",
+      "docsUrl": "https://docs.apechain.com",
+      "firehose": {
+        "blockType": "sf.ethereum.type.v2.Block",
+        "evmExtendedModel": false,
+        "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0xebbc9a87d1c945533b12311d15d11f7baab6d8c64f7aabe9d956f862554807a8",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
+      },
+      "icon": {
+        "web3Icons": {
+          "name": "apechain"
+        }
+      }
+    },
+    {
+      "id": "apechain",
+      "shortName": "ApeChain",
+      "fullName": "ApeChain Mainnet",
+      "aliases": [
+        "evm-33139",
+        "apechain-mainnet"
+      ],
+      "caip2Id": "eip155:33139",
+      "graphNode": {
+        "protocol": "ethereum"
+      },
+      "explorerUrls": [
+        "https://apescan.io"
+      ],
+      "rpcUrls": [
+        "https://rpc.apechain.com"
+      ],
+      "apiUrls": [
+        {
+          "url": "https://apechain.abi.pinax.network/api",
+          "kind": "etherscan"
+        }
+      ],
+      "services": {
+        "subgraphs": [
+          "https://api.studio.thegraph.com/deploy"
+        ]
+      },
+      "networkType": "mainnet",
+      "issuanceRewards": false,
+      "nativeToken": "APE",
+      "docsUrl": "https://docs.apechain.com",
+      "firehose": {
+        "blockType": "sf.ethereum.type.v2.Block",
+        "evmExtendedModel": false,
+        "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0xa217064039db238cd731edf0005e93b9ac72604247a8e7280e0606727f2d0736",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
+      },
+      "icon": {
+        "web3Icons": {
+          "name": "apechain"
+        }
+      }
+    },
+    {
+      "id": "peaq",
+      "shortName": "peaq",
+      "fullName": "Peaq Network",
+      "aliases": [
+        "evm-3338",
+        "peaq-mainnet"
+      ],
+      "caip2Id": "eip155:3338",
+      "graphNode": {
+        "protocol": "ethereum"
+      },
+      "explorerUrls": [
+        "https://peaq.subscan.io"
+      ],
+      "rpcUrls": [
+        "https://peaq.api.onfinality.io/public"
+      ],
+      "services": {
+        "subgraphs": [
+          "https://api.studio.thegraph.com/deploy"
+        ]
+      },
+      "networkType": "mainnet",
+      "issuanceRewards": false,
+      "nativeToken": "PEAQ",
+      "docsUrl": "https://docs.peaq.network",
+      "firehose": {
+        "blockType": "sf.ethereum.type.v2.Block",
+        "evmExtendedModel": true,
+        "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0x43ab0f195759cb56597b46c826459bf550afe0398a1421293c961b1fecda1783",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
+      },
+      "icon": {
+        "web3Icons": {
+          "name": "peaq"
         }
       }
     },
@@ -2480,21 +4611,23 @@
       ],
       "rpcUrls": [
         "https://mainnet.mode.network",
-        "https://mode.rpc.pinax.network/v1/{PINAX_API_KEY}"
+        "https://mode.rpc.service.pinax.network"
       ],
       "apiUrls": [
         {
           "url": "https://explorer.mode.network/api",
+          "kind": "blockscout"
+        },
+        {
+          "url": "https://api.routescan.io/v2/network/mainnet/evm/34443/etherscan/api",
           "kind": "etherscan"
         }
       ],
       "services": {
         "subgraphs": [
-          "https://api.thegraph.com/deploy"
+          "https://api.studio.thegraph.com/deploy"
         ],
-        "sps": [
-          "https://api.thegraph.com/deploy"
-        ],
+        "sps": [],
         "firehose": [
           "mode.firehose.pinax.network:443"
         ],
@@ -2509,24 +4642,27 @@
           "network": "mainnet"
         }
       ],
-      "issuanceRewards": false,
+      "issuanceRewards": true,
       "nativeToken": "ETH",
       "docsUrl": "https://docs.mode.network",
       "indexerDocsUrls": [
         {
           "url": "https://docs.infradao.com/archive-nodes-101/mode",
-          "description": "Arhchive Nodes 101"
+          "description": "Archive Nodes 101"
         }
       ],
-      "genesis": {
-        "hash": "0xb0f682e12fc555fd5ce8fce51a59a67d66a5b46be28611a168260a549dac8a9b",
-        "height": 0
-      },
       "firehose": {
         "blockType": "sf.ethereum.type.v2.Block",
         "evmExtendedModel": true,
         "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
-        "bytesEncoding": "hex"
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0xb0f682e12fc555fd5ce8fce51a59a67d66a5b46be28611a168260a549dac8a9b",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
       },
       "icon": {
         "web3Icons": {
@@ -2535,69 +4671,163 @@
       }
     },
     {
-      "id": "astar-zkevm-mainnet",
-      "shortName": "Astar",
-      "secondName": "zkEVM",
-      "fullName": "Astar zkEVM Mainnet",
+      "id": "botanix-testnet",
+      "shortName": "Botanix",
+      "fullName": "Botanix Testnet",
       "aliases": [
-        "evm-3776",
-        "astar",
-        "astar-zkevm"
+        "spiderchain-testnet",
+        "spiderchain-testnet-v1",
+        "evm-3636"
       ],
-      "caip2Id": "eip155:3776",
+      "caip2Id": "eip155:3636",
       "graphNode": {
         "protocol": "ethereum"
       },
       "explorerUrls": [
-        "https://astar-zkevm.explorer.startale.com"
+        "https://testnet.botanixscan.io"
       ],
       "rpcUrls": [
-        "https://rpc.startale.com/astar-zkevm",
-        "https://zkastar.rpc.pinax.network/v1/{PINAX_API_KEY}"
+        "https://node.botanixlabs.dev"
       ],
       "apiUrls": [
         {
-          "url": "https://astar-zkevm.explorer.startale.com/api",
+          "url": "https://api.routescan.io/v2/network/testnet/evm/3636/etherscan/api",
           "kind": "etherscan"
         }
       ],
       "services": {
         "subgraphs": [
-          "https://api.thegraph.com/deploy"
-        ],
-        "sps": [
-          "https://api.thegraph.com/deploy"
-        ],
-        "firehose": [
-          "zkastar.firehose.pinax.network:443"
-        ],
-        "substreams": [
-          "zkastar.substreams.pinax.network:443"
+          "https://api.studio.thegraph.com/deploy"
         ]
       },
-      "networkType": "mainnet",
+      "networkType": "testnet",
       "relations": [
         {
-          "kind": "l2Of",
-          "network": "mainnet"
+          "kind": "testnetOf",
+          "network": "botanix"
         }
       ],
       "issuanceRewards": false,
-      "nativeToken": "ETH",
-      "docsUrl": "https://docs.astar.network/docs/getting-started",
-      "genesis": {
-        "hash": "0x5f7b9f463b7a0b690efb11446d0520e5b884e5bf0e3a3780c881a3b490592574",
-        "height": 0
-      },
+      "nativeToken": "BTC",
+      "docsUrl": "https://docs.botanixlabs.xyz",
       "firehose": {
         "blockType": "sf.ethereum.type.v2.Block",
         "evmExtendedModel": false,
         "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
-        "bytesEncoding": "hex"
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0x3797638175875c37cefa72ef546db685e43c81ba4af8238b48a495f98d61588d",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
       },
       "icon": {
         "web3Icons": {
-          "name": "astar"
+          "name": "botanix"
+        }
+      }
+    },
+    {
+      "id": "botanix",
+      "shortName": "Botanix",
+      "fullName": "Botanix Mainnet",
+      "aliases": [
+        "evm-3637",
+        "botanix-mainnet"
+      ],
+      "caip2Id": "eip155:3637",
+      "graphNode": {
+        "protocol": "ethereum"
+      },
+      "services": {
+        "subgraphs": [
+          "https://api.studio.thegraph.com/deploy"
+        ]
+      },
+      "networkType": "mainnet",
+      "issuanceRewards": false,
+      "nativeToken": "BTC",
+      "docsUrl": "https://docs.botanixlabs.com",
+      "firehose": {
+        "blockType": "sf.ethereum.type.v2.Block",
+        "evmExtendedModel": false,
+        "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0x0210ae550e730d0e18f96896b80caad6f59dcc0b83b67421975716d155d027c6",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
+      },
+      "icon": {
+        "web3Icons": {
+          "name": "botanix"
+        }
+      }
+    },
+    {
+      "id": "lens-testnet",
+      "shortName": "Lens",
+      "fullName": "Lens Testnet",
+      "aliases": [
+        "evm-37111",
+        "lens-sepolia"
+      ],
+      "caip2Id": "eip155:37111",
+      "graphNode": {
+        "protocol": "ethereum"
+      },
+      "explorerUrls": [
+        "https://block-explorer.testnet.lens.dev"
+      ],
+      "rpcUrls": [
+        "https://rpc.testnet.lens.dev"
+      ],
+      "apiUrls": [
+        {
+          "url": "https://block-explorer-api.lens.dev/api",
+          "kind": "etherscan"
+        }
+      ],
+      "networkType": "testnet",
+      "relations": [
+        {
+          "kind": "l2Of",
+          "network": "sepolia"
+        },
+        {
+          "kind": "testnetOf",
+          "network": "lens"
+        }
+      ],
+      "services": {
+        "subgraphs": [
+          "https://api.studio.thegraph.com/deploy"
+        ]
+      },
+      "issuanceRewards": false,
+      "nativeToken": "GRASS",
+      "docsUrl": "https://www.lens.xyz/docs",
+      "firehose": {
+        "blockType": "sf.ethereum.type.v2.Block",
+        "evmExtendedModel": false,
+        "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0xe8e77626586f73b955364c7b4bbf0bb7f7685ebd40e852b164633a4acbd3244c",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
+      },
+      "icon": {
+        "web3Icons": {
+          "name": "lens"
         }
       }
     },
@@ -2626,7 +4856,7 @@
       ],
       "services": {
         "subgraphs": [
-          "https://api.thegraph.com/deploy"
+          "https://api.studio.thegraph.com/deploy"
         ]
       },
       "networkType": "testnet",
@@ -2639,15 +4869,18 @@
       "issuanceRewards": false,
       "nativeToken": "FTM",
       "docsUrl": "https://docs.fantom.foundation",
-      "genesis": {
-        "hash": "0x00000000000000009a0c7349d44dc4d0f602a54e0a8543360c2fee4c3937b49e",
-        "height": 0
-      },
       "firehose": {
         "blockType": "sf.ethereum.type.v2.Block",
         "evmExtendedModel": false,
         "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
-        "bytesEncoding": "hex"
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0x00000000000000009a0c7349d44dc4d0f602a54e0a8543360c2fee4c3937b49e",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
       },
       "icon": {
         "web3Icons": {
@@ -2657,14 +4890,13 @@
     },
     {
       "id": "arbitrum-one",
-      "shortName": "Arbitrum",
-      "secondName": "One",
+      "shortName": "Arbitrum One",
       "fullName": "Arbitrum One Mainnet",
       "aliases": [
         "arbone",
         "arbitrum",
-        "arb-sepolia",
-        "evm-42161"
+        "evm-42161",
+        "arbitrum-one-mainnet"
       ],
       "caip2Id": "eip155:42161",
       "graphNode": {
@@ -2684,21 +4916,23 @@
         "https://arb1.arbitrum.io/rpc",
         "https://arb-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}",
         "https://arbitrum-mainnet.infura.io/v3/${INFURA_API_KEY}",
-        "https://arbone.rpc.pinax.network/v1/{PINAX_API_KEY}"
+        "https://arbone.rpc.service.pinax.network"
       ],
       "apiUrls": [
         {
           "url": "https://arbitrum-one.abi.pinax.network/api",
           "kind": "etherscan"
+        },
+        {
+          "url": "https://arbitrum.blockscout.com/api",
+          "kind": "blockscout"
         }
       ],
       "services": {
         "subgraphs": [
-          "https://api.thegraph.com/deploy"
+          "https://api.studio.thegraph.com/deploy"
         ],
-        "sps": [
-          "https://api.thegraph.com/deploy"
-        ],
+        "sps": [],
         "firehose": [
           "arbone.firehose.pinax.network:443",
           "arb-one.streamingfast.io:443"
@@ -2706,6 +4940,9 @@
         "substreams": [
           "arbone.substreams.pinax.network:443",
           "arb-one.streamingfast.io:443"
+        ],
+        "tokenApi": [
+          "https://token-api.thegraph.com"
         ]
       },
       "networkType": "mainnet",
@@ -2715,18 +4952,29 @@
       "indexerDocsUrls": [
         {
           "url": "https://docs.infradao.com/archive-nodes-101/arbitrum",
-          "description": "Arhchive Nodes 101"
+          "description": "Archive Nodes 101"
         }
       ],
-      "genesis": {
-        "hash": "0x7ee576b35482195fc49205cec9af72ce14f003b9ae69f6ba0faef4514be8b442",
-        "height": 0
-      },
       "firehose": {
         "blockType": "sf.ethereum.type.v2.Block",
         "evmExtendedModel": true,
         "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
-        "bytesEncoding": "hex"
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0x7ee576b35482195fc49205cec9af72ce14f003b9ae69f6ba0faef4514be8b442",
+          "height": 0
+        },
+        "blockFeatures": [
+          "hybrid"
+        ]
+      },
+      "tokenApi": {
+        "features": [
+          "tokens",
+          "dexes",
+          "nfts"
+        ],
+        "networkId": "arbitrum-one"
       },
       "icon": {
         "web3Icons": {
@@ -2740,7 +4988,8 @@
       "secondName": "Sepolia",
       "fullName": "Arbitrum Sepolia Testnet",
       "aliases": [
-        "evm-421614"
+        "evm-421614",
+        "arb-sepolia"
       ],
       "caip2Id": "eip155:421614",
       "networkType": "testnet",
@@ -2762,7 +5011,7 @@
       ],
       "rpcUrls": [
         "https://sepolia-rollup.arbitrum.io/rpc",
-        "https://arbsepolia.rpc.pinax.network/v1/{PINAX_API_KEY}"
+        "https://arbsepolia.rpc.service.pinax.network"
       ],
       "apiUrls": [
         {
@@ -2772,11 +5021,9 @@
       ],
       "services": {
         "subgraphs": [
-          "https://api.thegraph.com/deploy"
+          "https://api.studio.thegraph.com/deploy"
         ],
-        "sps": [
-          "https://api.thegraph.com/deploy"
-        ],
+        "sps": [],
         "firehose": [
           "arbsepolia.firehose.pinax.network:443"
         ],
@@ -2784,18 +5031,27 @@
           "arbsepolia.substreams.pinax.network:443"
         ]
       },
-      "issuanceRewards": false,
+      "issuanceRewards": true,
       "nativeToken": "ETH",
       "docsUrl": "https://docs.arbitrum.io",
-      "genesis": {
-        "hash": "0x77194da4010e549a7028a9c3c51c3e277823be6ac7d138d0bb8a70197b5c004c",
-        "height": 0
-      },
+      "indexerDocsUrls": [
+        {
+          "url": "https://docs.infradao.com/archive-nodes-101/arbitrum-sepolia",
+          "description": "Archive Nodes 101"
+        }
+      ],
       "firehose": {
         "blockType": "sf.ethereum.type.v2.Block",
         "evmExtendedModel": true,
         "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
-        "bytesEncoding": "hex"
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0x77194da4010e549a7028a9c3c51c3e277823be6ac7d138d0bb8a70197b5c004c",
+          "height": 0
+        },
+        "blockFeatures": [
+          "extended"
+        ]
       },
       "icon": {
         "web3Icons": {
@@ -2805,9 +5061,8 @@
     },
     {
       "id": "arbitrum-nova",
-      "shortName": "Arbitrum",
-      "secondName": "Nova",
-      "fullName": "Arbitrum Nova",
+      "shortName": "Arbitrum Nova",
+      "fullName": "Arbitrum Nova Mainnet",
       "aliases": [
         "evm-42170",
         "arbnova",
@@ -2824,7 +5079,7 @@
       "rpcUrls": [
         "https://nova.arbitrum.io/rpc",
         "https://arbitrum-nova.publicnode.com",
-        "https://arbnova.rpc.pinax.network/v1/{PINAX_API_KEY}"
+        "https://arbnova.rpc.service.pinax.network"
       ],
       "apiUrls": [
         {
@@ -2834,11 +5089,9 @@
       ],
       "services": {
         "subgraphs": [
-          "https://api.thegraph.com/deploy"
+          "https://api.studio.thegraph.com/deploy"
         ],
-        "sps": [
-          "https://api.thegraph.com/deploy"
-        ],
+        "sps": [],
         "firehose": [
           "arbnova.firehose.pinax.network:443"
         ],
@@ -2856,15 +5109,18 @@
       "issuanceRewards": false,
       "nativeToken": "ETH",
       "docsUrl": "https://docs.arbitrum.io",
-      "genesis": {
-        "hash": "0x2ad24e03026118f9b3a48626f0636e38c93660e90a6812e853a99aa8c5371561",
-        "height": 0
-      },
       "firehose": {
         "blockType": "sf.ethereum.type.v2.Block",
-        "evmExtendedModel": false,
+        "evmExtendedModel": true,
         "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
-        "bytesEncoding": "hex"
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0x2ad24e03026118f9b3a48626f0636e38c93660e90a6812e853a99aa8c5371561",
+          "height": 0
+        },
+        "blockFeatures": [
+          "extended"
+        ]
       },
       "icon": {
         "web3Icons": {
@@ -2888,17 +5144,22 @@
         "https://celoscan.io"
       ],
       "rpcUrls": [
-        "https://forno.celo.org"
+        "https://forno.celo.org",
+        "https://celo.rpc.service.pinax.network"
       ],
       "apiUrls": [
         {
           "url": "https://celo.abi.pinax.network/api",
           "kind": "etherscan"
+        },
+        {
+          "url": "https://explorer.celo.org/mainnet/api",
+          "kind": "blockscout"
         }
       ],
       "services": {
         "subgraphs": [
-          "https://api.thegraph.com/deploy"
+          "https://api.studio.thegraph.com/deploy"
         ]
       },
       "networkType": "mainnet",
@@ -2908,18 +5169,21 @@
       "indexerDocsUrls": [
         {
           "url": "https://docs.infradao.com/archive-nodes-101/celo",
-          "description": "Arhchive Nodes 101"
+          "description": "Archive Nodes 101"
         }
       ],
-      "genesis": {
-        "hash": "0x19ea3339d3c8cda97235bc8293240d5b9dadcdfbb5d4b0b90ee731cac1bd11c3",
-        "height": 0
-      },
       "firehose": {
         "blockType": "sf.ethereum.type.v2.Block",
         "evmExtendedModel": false,
         "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
-        "bytesEncoding": "hex"
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0x19ea3339d3c8cda97235bc8293240d5b9dadcdfbb5d4b0b90ee731cac1bd11c3",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
       },
       "icon": {
         "web3Icons": {
@@ -2947,31 +5211,92 @@
       "apiUrls": [
         {
           "url": "https://explorer.etherlink.com/api",
-          "kind": "etherscan"
+          "kind": "blockscout"
         }
       ],
       "services": {
         "subgraphs": [
-          "https://api.thegraph.com/deploy"
+          "https://api.studio.thegraph.com/deploy"
         ]
       },
       "networkType": "mainnet",
       "issuanceRewards": false,
       "nativeToken": "XTZ",
       "docsUrl": "https://docs.etherlink.com",
-      "genesis": {
-        "hash": "0x37628d45dcd6265c969aa5f5dc3fe8fddd21198c683b85ac7099d8e39597df50",
-        "height": 0
-      },
       "firehose": {
         "blockType": "sf.ethereum.type.v2.Block",
         "evmExtendedModel": false,
         "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
-        "bytesEncoding": "hex"
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0x37628d45dcd6265c969aa5f5dc3fe8fddd21198c683b85ac7099d8e39597df50",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
       },
       "icon": {
         "web3Icons": {
           "name": "etherlink"
+        }
+      }
+    },
+    {
+      "id": "hemi",
+      "shortName": "Hemi",
+      "fullName": "Hemi Mainnet",
+      "aliases": [
+        "evm-43111",
+        "hemi-mainnet"
+      ],
+      "caip2Id": "eip155:43111",
+      "graphNode": {
+        "protocol": "ethereum"
+      },
+      "explorerUrls": [
+        "https://explorer.hemi.xyz"
+      ],
+      "apiUrls": [
+        {
+          "url": "https://explorer.hemi.xyz/api",
+          "kind": "etherscan"
+        }
+      ],
+      "rpcUrls": [
+        "https://rpc.hemi.network/rpc"
+      ],
+      "services": {
+        "subgraphs": [
+          "https://api.studio.thegraph.com/deploy"
+        ]
+      },
+      "networkType": "mainnet",
+      "relations": [
+        {
+          "kind": "l2Of",
+          "network": "mainnet"
+        }
+      ],
+      "issuanceRewards": false,
+      "nativeToken": "ETH",
+      "docsUrl": "https://docs.hemi.xyz",
+      "firehose": {
+        "blockType": "sf.ethereum.type.v2.Block",
+        "evmExtendedModel": false,
+        "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0x6b070d8b8f3bf81c9314ff863748e3db2662ecc0a8dbd4c394a8b646ae0c8b8b",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
+      },
+      "icon": {
+        "web3Icons": {
+          "name": "hemi"
         }
       }
     },
@@ -2992,18 +5317,25 @@
         "https://testnet.snowscan.xyz"
       ],
       "rpcUrls": [
-        "https://api.avax-test.network/ext/bc/C/rpc",
-        "https://fuji.rpc.pinax.network/v1/{PINAX_API_KEY}/ext/bc/C/rpc"
+        "https://api.avax-test.network/ext/bc/C/rpc"
       ],
       "apiUrls": [
         {
+          "url": "https://fuji.abi.pinax.network/api",
+          "kind": "etherscan"
+        },
+        {
           "url": "https://api-testnet.snowtrace.io/api",
+          "kind": "etherscan"
+        },
+        {
+          "url": "https://api.routescan.io/v2/network/testnet/evm/43113/etherscan/api",
           "kind": "etherscan"
         }
       ],
       "services": {
         "subgraphs": [
-          "https://api.thegraph.com/deploy"
+          "https://api.studio.thegraph.com/deploy"
         ]
       },
       "networkType": "testnet",
@@ -3016,15 +5348,18 @@
       "issuanceRewards": false,
       "nativeToken": "AVAX",
       "docsUrl": "https://docs.avax.network",
-      "genesis": {
-        "hash": "0x738639479dc82d199365626f90caa82f7eafcfe9ed354b456fb3d294597ceb53",
-        "height": 1
-      },
       "firehose": {
         "blockType": "sf.ethereum.type.v2.Block",
         "evmExtendedModel": false,
         "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
-        "bytesEncoding": "hex"
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0x31ced5b9beb7f8782b014660da0cb18cc409f121f408186886e1ca3e8eeca96b",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
       },
       "icon": {
         "web3Icons": {
@@ -3050,22 +5385,27 @@
       ],
       "rpcUrls": [
         "https://api.avax.network/ext/bc/C/rpc",
-        "https://avalanche.rpc.pinax.network/v1/{PINAX_API_KEY}/ext/bc/C/rpc",
         "https://avalanche-c-chain-rpc.publicnode.com"
       ],
       "apiUrls": [
         {
+          "url": "https://avalanche.abi.pinax.network/api",
+          "kind": "etherscan"
+        },
+        {
           "url": "https://api.snowtrace.io/api",
+          "kind": "etherscan"
+        },
+        {
+          "url": "https://api.routescan.io/v2/network/mainnet/evm/43114/etherscan/api",
           "kind": "etherscan"
         }
       ],
       "services": {
         "subgraphs": [
-          "https://api.thegraph.com/deploy"
+          "https://api.studio.thegraph.com/deploy"
         ],
-        "sps": [
-          "https://api.thegraph.com/deploy"
-        ],
+        "sps": [],
         "firehose": [
           "avalanche-mainnet.streamingfast.io:443",
           "avalanche.firehose.pinax.network:443"
@@ -3073,6 +5413,9 @@
         "substreams": [
           "avalanche-mainnet.streamingfast.io:443",
           "avalanche.substreams.pinax.network:443"
+        ],
+        "tokenApi": [
+          "https://token-api.thegraph.com"
         ]
       },
       "networkType": "mainnet",
@@ -3082,18 +5425,29 @@
       "indexerDocsUrls": [
         {
           "url": "https://docs.infradao.com/archive-nodes-101/avalanche",
-          "description": "Arhchive Nodes 101"
+          "description": "Archive Nodes 101"
         }
       ],
-      "genesis": {
-        "hash": "0x31ced5b9beb7f8782b014660da0cb18cc409f121f408186886e1ca3e8eeca96b",
-        "height": 0
-      },
       "firehose": {
         "blockType": "sf.ethereum.type.v2.Block",
         "evmExtendedModel": false,
         "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
-        "bytesEncoding": "hex"
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0x31ced5b9beb7f8782b014660da0cb18cc409f121f408186886e1ca3e8eeca96b",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
+      },
+      "tokenApi": {
+        "features": [
+          "tokens",
+          "dexes",
+          "nfts"
+        ],
+        "networkId": "avalanche"
       },
       "icon": {
         "web3Icons": {
@@ -3126,31 +5480,38 @@
       ],
       "rpcUrls": [
         "https://alfajores-forno.celo-testnet.org",
-        "https://alfajores.rpc.pinax.network/v1/{PINAX_API_KEY}"
+        "https://alfajores.rpc.service.pinax.network"
       ],
       "apiUrls": [
         {
           "url": "https://celo-alfajores.abi.pinax.network/api",
           "kind": "etherscan"
+        },
+        {
+          "url": "https://celo-alfajores.blockscout.com/api",
+          "kind": "blockscout"
         }
       ],
       "services": {
         "subgraphs": [
-          "https://api.thegraph.com/deploy"
+          "https://api.studio.thegraph.com/deploy"
         ]
       },
       "issuanceRewards": false,
       "nativeToken": "CELO",
       "docsUrl": "https://docs.celo.org",
-      "genesis": {
-        "hash": "0xe423b034e7f0282c1b621f7bbc1cea4316a2a80b1600490769eae77777e4b67e",
-        "height": 0
-      },
       "firehose": {
         "blockType": "sf.ethereum.type.v2.Block",
         "evmExtendedModel": false,
         "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
-        "bytesEncoding": "hex"
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0xe423b034e7f0282c1b621f7bbc1cea4316a2a80b1600490769eae77777e4b67e",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
       },
       "icon": {
         "web3Icons": {
@@ -3178,28 +5539,95 @@
       ],
       "apiUrls": [
         {
-          "url": "https://iotexscan.io/api",
+          "url": "https://index.iotexscan.io/api",
           "kind": "etherscan"
         }
       ],
       "services": {
         "subgraphs": [
-          "https://api.thegraph.com/deploy"
+          "https://api.studio.thegraph.com/deploy"
         ]
       },
       "networkType": "mainnet",
       "issuanceRewards": false,
       "nativeToken": "IOTX",
       "docsUrl": "https://docs.iotex.io",
-      "genesis": {
-        "hash": "0x230ba8095d5a505e355652f9dcc2b13605419a8fa3d3fd5ddc6d24fd6a902641",
-        "height": 1
-      },
+      "indexerDocsUrls": [
+        {
+          "url": "https://docs.infradao.com/archive-nodes-101/iotex",
+          "description": "Archive Nodes 101"
+        }
+      ],
       "firehose": {
         "blockType": "sf.ethereum.type.v2.Block",
         "evmExtendedModel": false,
         "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
-        "bytesEncoding": "hex"
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0xb337983730981c2d50f114eed5da9dd20b83c8c5e130beefdb3001dc858cfe8b",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
+      },
+      "icon": {
+        "web3Icons": {
+          "name": "iotex"
+        }
+      }
+    },
+    {
+      "id": "iotex-testnet",
+      "shortName": "Iotex",
+      "secondName": "Testnet",
+      "fullName": "Iotex Testnet",
+      "aliases": [
+        "evm-4690"
+      ],
+      "caip2Id": "eip155:4690",
+      "graphNode": {
+        "protocol": "ethereum"
+      },
+      "explorerUrls": [
+        "https://testnet.iotexscan.io"
+      ],
+      "rpcUrls": [
+        "https://babel-api.testnet.iotex.io"
+      ],
+      "apiUrls": [
+        {
+          "url": "https://testnet.index.iotexscan.io/api",
+          "kind": "etherscan"
+        }
+      ],
+      "services": {
+        "subgraphs": [
+          "https://api.studio.thegraph.com/deploy"
+        ]
+      },
+      "networkType": "testnet",
+      "relations": [
+        {
+          "kind": "testnetOf",
+          "network": "iotex"
+        }
+      ],
+      "issuanceRewards": false,
+      "nativeToken": "IOTX",
+      "docsUrl": "https://docs.iotex.io",
+      "firehose": {
+        "blockType": "sf.ethereum.type.v2.Block",
+        "evmExtendedModel": false,
+        "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0x5e31a9f95ca4de82bd6f5ed9b465c6474bba27f1c5d31747393a555ce1f41607",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
       },
       "icon": {
         "web3Icons": {
@@ -3233,26 +5661,81 @@
       ],
       "services": {
         "subgraphs": [
-          "https://api.thegraph.com/deploy"
+          "https://api.studio.thegraph.com/deploy"
         ]
       },
       "networkType": "mainnet",
       "issuanceRewards": false,
       "nativeToken": "GAS",
       "docsUrl": "https://xdocs.ngd.network",
-      "genesis": {
-        "hash": "0x2ee57478315c7d3182997a812d7885dafee48612cd88cb30b615847b0dd8dbd7",
-        "height": 0
-      },
       "firehose": {
         "blockType": "sf.ethereum.type.v2.Block",
         "evmExtendedModel": false,
         "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
-        "bytesEncoding": "hex"
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0x2ee57478315c7d3182997a812d7885dafee48612cd88cb30b615847b0dd8dbd7",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
       },
       "icon": {
         "web3Icons": {
           "name": "neo-x"
+        }
+      }
+    },
+    {
+      "id": "autonomys-taurus",
+      "shortName": "Autonomys",
+      "fullName": "Autonomys Taurus Auto EVM",
+      "aliases": [
+        "evm-490000",
+        "autonomys-testnet"
+      ],
+      "caip2Id": "eip155:490000",
+      "graphNode": {
+        "protocol": "ethereum"
+      },
+      "explorerUrls": [
+        "https://blockscout.taurus.autonomys.xyz"
+      ],
+      "rpcUrls": [
+        "https://auto-evm.taurus.autonomys.xyz/ws"
+      ],
+      "apiUrls": [
+        {
+          "url": "https://blockscout.taurus.autonomys.xyz/api",
+          "kind": "blockscout"
+        }
+      ],
+      "services": {
+        "subgraphs": [
+          "https://api.studio.thegraph.com/deploy"
+        ]
+      },
+      "networkType": "testnet",
+      "issuanceRewards": false,
+      "nativeToken": "AI3",
+      "docsUrl": "https://docs.autonomys.xyz",
+      "firehose": {
+        "blockType": "sf.ethereum.type.v2.Block",
+        "evmExtendedModel": true,
+        "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0x085b6a1088858e39e9f26e832db9ba44e7f8ca977f363f0aff79f8bec5abb8b9",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
+      },
+      "icon": {
+        "web3Icons": {
+          "name": "autonomys"
         }
       }
     },
@@ -3274,17 +5757,21 @@
       ],
       "rpcUrls": [
         "https://sepolia-rpc.scroll.io",
-        "https://scrsepolia.rpc.pinax.network/v1/{PINAX_API_KEY}"
+        "https://scrsepolia.rpc.service.pinax.network"
       ],
       "apiUrls": [
         {
-          "url": "https://api-sepolia.scrollscan.com/api",
+          "url": "https://scroll-sepolia.blockscout.com/api",
+          "kind": "blockscout"
+        },
+        {
+          "url": "https://scroll-sepolia.abi.pinax.network/api",
           "kind": "etherscan"
         }
       ],
       "services": {
         "subgraphs": [
-          "https://api.thegraph.com/deploy"
+          "https://api.studio.thegraph.com/deploy"
         ],
         "firehose": [
           "scrsepolia.firehose.pinax.network:443"
@@ -3307,15 +5794,18 @@
       "issuanceRewards": false,
       "nativeToken": "ETH",
       "docsUrl": "https://docs.scroll.io",
-      "genesis": {
-        "hash": "0xaa62d1a8b2bffa9e5d2368b63aae0d98d54928bd713125e3fd9e5c896c68592c",
-        "height": 0
-      },
       "firehose": {
         "blockType": "sf.ethereum.type.v2.Block",
         "evmExtendedModel": false,
         "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
-        "bytesEncoding": "hex"
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0xaa62d1a8b2bffa9e5d2368b63aae0d98d54928bd713125e3fd9e5c896c68592c",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
       },
       "icon": {
         "web3Icons": {
@@ -3340,22 +5830,24 @@
       ],
       "rpcUrls": [
         "https://rpc.scroll.io",
-        "https://scroll.rpc.pinax.network/v1/{PINAX_API_KEY}",
+        "https://scroll.rpc.service.pinax.network",
         "https://rpc.ankr.com/scroll"
       ],
       "apiUrls": [
         {
-          "url": "https://api.scrollscan.com/api",
+          "url": "https://scroll.blockscout.com/api",
+          "kind": "blockscout"
+        },
+        {
+          "url": "https://scroll.abi.pinax.network/api",
           "kind": "etherscan"
         }
       ],
       "services": {
         "subgraphs": [
-          "https://api.thegraph.com/deploy"
+          "https://api.studio.thegraph.com/deploy"
         ],
-        "sps": [
-          "https://api.thegraph.com/deploy"
-        ],
+        "sps": [],
         "firehose": [
           "scroll.firehose.pinax.network:443"
         ],
@@ -3376,18 +5868,21 @@
       "indexerDocsUrls": [
         {
           "url": "https://docs.infradao.com/archive-nodes-101/scroll",
-          "description": "Arhchive Nodes 101"
+          "description": "Archive Nodes 101"
         }
       ],
-      "genesis": {
-        "hash": "0xbbc05efd412b7cd47a2ed0e5ddfcf87af251e414ea4c801d78b6784513180a80",
-        "height": 0
-      },
       "firehose": {
         "blockType": "sf.ethereum.type.v2.Block",
         "evmExtendedModel": false,
         "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
-        "bytesEncoding": "hex"
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0xbbc05efd412b7cd47a2ed0e5ddfcf87af251e414ea4c801d78b6784513180a80",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
       },
       "icon": {
         "web3Icons": {
@@ -3415,22 +5910,20 @@
       "rpcUrls": [
         "https://bsc-dataseed1.binance.org",
         "https://bsc-dataseed1.defibit.io",
-        "https://bsc.rpc.pinax.network/v1/{PINAX_API_KEY}"
+        "https://bsc.rpc.service.pinax.network"
       ],
       "apiUrls": [
         {
-          "url": "https://api.bscscan.com/api",
+          "url": "https://bsc.abi.pinax.network/api",
           "kind": "etherscan"
         }
       ],
       "networkType": "mainnet",
       "services": {
         "subgraphs": [
-          "https://api.thegraph.com/deploy"
+          "https://api.studio.thegraph.com/deploy"
         ],
-        "sps": [
-          "https://api.thegraph.com/deploy"
-        ],
+        "sps": [],
         "firehose": [
           "bsc.firehose.pinax.network:443",
           "bnb.streamingfast.io:443"
@@ -3438,6 +5931,9 @@
         "substreams": [
           "bsc.substreams.pinax.network:443",
           "bnb.streamingfast.io:443"
+        ],
+        "tokenApi": [
+          "https://token-api.thegraph.com"
         ]
       },
       "issuanceRewards": true,
@@ -3446,18 +5942,29 @@
       "indexerDocsUrls": [
         {
           "url": "https://docs.infradao.com/archive-nodes-101/binance",
-          "description": "Arhchive Nodes 101"
+          "description": "Archive Nodes 101"
         }
       ],
-      "genesis": {
-        "hash": "0x0d21840abff46b96c84b2ac9e10e4f5cdaeb5693cb665db62a2f3b02d2d57b5b",
-        "height": 0
-      },
       "firehose": {
         "blockType": "sf.ethereum.type.v2.Block",
         "evmExtendedModel": true,
         "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
-        "bytesEncoding": "hex"
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0x0d21840abff46b96c84b2ac9e10e4f5cdaeb5693cb665db62a2f3b02d2d57b5b",
+          "height": 0
+        },
+        "blockFeatures": [
+          "extended"
+        ]
+      },
+      "tokenApi": {
+        "features": [
+          "tokens",
+          "dexes",
+          "nfts"
+        ],
+        "networkId": "bsc"
       },
       "icon": {
         "web3Icons": {
@@ -3466,13 +5973,77 @@
       }
     },
     {
+      "id": "hoodi",
+      "shortName": "Ethereum",
+      "secondName": "Hoodi",
+      "fullName": "Ethereum Hoodi Testnet",
+      "aliases": [
+        "evm-560048"
+      ],
+      "caip2Id": "eip155:560048",
+      "networkType": "testnet",
+      "relations": [
+        {
+          "kind": "testnetOf",
+          "network": "mainnet"
+        }
+      ],
+      "graphNode": {
+        "protocol": "ethereum"
+      },
+      "explorerUrls": [
+        "https://hoodi.etherscan.io"
+      ],
+      "rpcUrls": [
+        "https://0xrpc.io/hoodi",
+        "https://hoodi.rpc.service.pinax.network"
+      ],
+      "apiUrls": [
+        {
+          "url": "https://hoodi.abi.pinax.network/api",
+          "kind": "etherscan"
+        }
+      ],
+      "services": {
+        "subgraphs": [
+          "https://api.studio.thegraph.com/deploy"
+        ],
+        "firehose": [
+          "hoodi.firehose.pinax.network:443"
+        ],
+        "substreams": [
+          "hoodi.substreams.pinax.network:443"
+        ]
+      },
+      "issuanceRewards": false,
+      "nativeToken": "ETH",
+      "firehose": {
+        "blockType": "sf.ethereum.type.v2.Block",
+        "evmExtendedModel": true,
+        "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0xbbe312868b376a3001692a646dd2d7d1e4406380dfd86b98aa8a34d1557c971b",
+          "height": 0
+        },
+        "blockFeatures": [
+          "extended"
+        ]
+      },
+      "icon": {
+        "web3Icons": {
+          "name": "ethereum"
+        }
+      }
+    },
+    {
       "id": "boba-bnb",
-      "shortName": "Boba",
-      "secondName": "BNB",
+      "shortName": "Boba BNB",
       "fullName": "Boba BNB Mainnet",
       "aliases": [
         "evm-56288",
-        "boba-bsc"
+        "boba-bsc",
+        "boba-bnb-mainnet"
       ],
       "caip2Id": "eip155:56288",
       "graphNode": {
@@ -3484,7 +6055,7 @@
       "rpcUrls": [
         "https://bnb.boba.network",
         "https://boba-bnb.gateway.tenderly.co",
-        "https://bobabnb.rpc.pinax.network/v1/{PINAX_API_KEY}"
+        "https://bobabnb.rpc.service.pinax.network"
       ],
       "apiUrls": [
         {
@@ -3494,7 +6065,7 @@
       ],
       "services": {
         "subgraphs": [
-          "https://api.thegraph.com/deploy"
+          "https://api.studio.thegraph.com/deploy"
         ],
         "firehose": [
           "bobabnb.firehose.pinax.network:443"
@@ -3516,22 +6087,77 @@
       "indexerDocsUrls": [
         {
           "url": "https://docs.infradao.com/archive-nodes-101/bobabnb",
-          "description": "Arhchive Nodes 101"
+          "description": "Archive Nodes 101"
         }
       ],
-      "genesis": {
-        "hash": "0xf9aa25373a3cf1c3d3dcb1911093b56eb129221d203270bcdb002b3f01a120d9",
-        "height": 0
-      },
       "firehose": {
         "blockType": "sf.ethereum.type.v2.Block",
         "evmExtendedModel": false,
         "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
-        "bytesEncoding": "hex"
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0xf9aa25373a3cf1c3d3dcb1911093b56eb129221d203270bcdb002b3f01a120d9",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
       },
       "icon": {
         "web3Icons": {
           "name": "boba"
+        }
+      }
+    },
+    {
+      "id": "ink",
+      "shortName": "Ink",
+      "fullName": "Ink Mainnet",
+      "aliases": [
+        "evm-57073",
+        "ink-mainnet"
+      ],
+      "caip2Id": "eip155:57073",
+      "graphNode": {
+        "protocol": "ethereum"
+      },
+      "explorerUrls": [
+        "https://explorer.inkonchain.com"
+      ],
+      "apiUrls": [
+        {
+          "url": "https://explorer.inkonchain.com/api",
+          "kind": "blockscout"
+        }
+      ],
+      "rpcUrls": [
+        "https://rpc-gel.inkonchain.com"
+      ],
+      "services": {
+        "subgraphs": [
+          "https://api.studio.thegraph.com/deploy"
+        ]
+      },
+      "networkType": "mainnet",
+      "issuanceRewards": false,
+      "nativeToken": "ETH",
+      "docsUrl": "https://docs.inkonchain.com",
+      "firehose": {
+        "blockType": "sf.ethereum.type.v2.Block",
+        "evmExtendedModel": true,
+        "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0x23a2658170ba70d014ba0d0d2709f8fbfe2fa660cd868c5f282f991eecbe38ee",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
+      },
+      "icon": {
+        "web3Icons": {
+          "name": "ink"
         }
       }
     },
@@ -3552,17 +6178,28 @@
         "https://sepolia.lineascan.build"
       ],
       "rpcUrls": [
-        "https://rpc.sepolia.linea.build"
+        "https://rpc.sepolia.linea.build",
+        "https://lineasepolia.rpc.service.pinax.network"
       ],
       "apiUrls": [
         {
           "url": "https://linea-sepolia.abi.pinax.network/api",
           "kind": "etherscan"
+        },
+        {
+          "url": "https://api-explorer.sepolia.linea.build/api",
+          "kind": "blockscout"
         }
       ],
       "services": {
         "subgraphs": [
-          "https://api.thegraph.com/deploy"
+          "https://api.studio.thegraph.com/deploy"
+        ],
+        "firehose": [
+          "lineasepolia.firehose.pinax.network:443"
+        ],
+        "substreams": [
+          "lineasepolia.substreams.pinax.network:443"
         ]
       },
       "networkType": "testnet",
@@ -3579,15 +6216,18 @@
       "issuanceRewards": false,
       "nativeToken": "ETH",
       "docsUrl": "https://docs.linea.build",
-      "genesis": {
-        "hash": "0x65a64c825d7c13ce1bf077801d0b6b2a89853e19e4a89a5433d7d85d2102a20b",
-        "height": 0
-      },
       "firehose": {
         "blockType": "sf.ethereum.type.v2.Block",
-        "evmExtendedModel": false,
+        "evmExtendedModel": true,
         "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
-        "bytesEncoding": "hex"
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0x65a64c825d7c13ce1bf077801d0b6b2a89853e19e4a89a5433d7d85d2102a20b",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
       },
       "icon": {
         "web3Icons": {
@@ -3612,18 +6252,22 @@
       ],
       "rpcUrls": [
         "https://rpc.linea.build",
-        "https://linea.rpc.pinax.network/v1/{PINAX_API_KEY}",
+        "https://linea.rpc.service.pinax.network",
         "https://linea-mainnet.infura.io/v3/${INFURA_API_KEY}"
       ],
       "apiUrls": [
         {
           "url": "https://linea.abi.pinax.network/api",
           "kind": "etherscan"
+        },
+        {
+          "url": "https://api-explorer.linea.build/api",
+          "kind": "blockscout"
         }
       ],
       "services": {
         "subgraphs": [
-          "https://api.thegraph.com/deploy"
+          "https://api.studio.thegraph.com/deploy"
         ],
         "firehose": [
           "linea.firehose.pinax.network:443"
@@ -3645,22 +6289,70 @@
       "indexerDocsUrls": [
         {
           "url": "https://docs.infradao.com/archive-nodes-101/linea",
-          "description": "Arhchive Nodes 101"
+          "description": "Archive Nodes 101"
         }
       ],
-      "genesis": {
-        "hash": "0xb6762a65689107b2326364aefc18f94cda413209fab35c00d4af51eaa20ffbc6",
-        "height": 0
-      },
       "firehose": {
         "blockType": "sf.ethereum.type.v2.Block",
-        "evmExtendedModel": false,
+        "evmExtendedModel": true,
         "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
-        "bytesEncoding": "hex"
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0xb6762a65689107b2326364aefc18f94cda413209fab35c00d4af51eaa20ffbc6",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
       },
       "icon": {
         "web3Icons": {
           "name": "linea"
+        }
+      }
+    },
+    {
+      "id": "megaeth-testnet",
+      "shortName": "MegaETH",
+      "secondName": "Testnet",
+      "fullName": "MegaETH Testnet",
+      "aliases": [
+        "evm-6342"
+      ],
+      "caip2Id": "eip155:6342",
+      "networkType": "testnet",
+      "graphNode": {
+        "protocol": "ethereum"
+      },
+      "explorerUrls": [
+        "https://www.megaexplorer.xyz"
+      ],
+      "rpcUrls": [
+        "https://carrot.megaeth.com/rpc"
+      ],
+      "services": {
+        "subgraphs": [
+          "https://api.studio.thegraph.com/deploy"
+        ]
+      },
+      "issuanceRewards": false,
+      "nativeToken": "ETH",
+      "firehose": {
+        "blockType": "sf.ethereum.type.v2.Block",
+        "evmExtendedModel": true,
+        "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0xe56bd7ae2a26376ed01d4775edcec3fc18817451137e4a06a5899bf478b75500",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
+      },
+      "icon": {
+        "web3Icons": {
+          "name": "mega-eth"
         }
       }
     },
@@ -3681,11 +6373,15 @@
       ],
       "rpcUrls": [
         "https://xai-chain.net/rpc",
-        "https://xai.rpc.pinax.network/v1/{PINAX_API_KEY}"
+        "https://xai.rpc.service.pinax.network"
       ],
       "apiUrls": [
         {
           "url": "https://explorer.xai-chain.net/api",
+          "kind": "blockscout"
+        },
+        {
+          "url": "https://xai.abi.pinax.network/api",
           "kind": "etherscan"
         }
       ],
@@ -3707,19 +6403,312 @@
       "issuanceRewards": false,
       "nativeToken": "XAI",
       "docsUrl": "https://docs.x.ai/docs",
-      "genesis": {
-        "hash": "0xeb2a6f0f62cc7956562dc4e6316b60bdaff6a15affd6431592cb52f1552caa55",
-        "height": 0
-      },
       "firehose": {
         "blockType": "sf.ethereum.type.v2.Block",
-        "evmExtendedModel": false,
+        "evmExtendedModel": true,
         "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
-        "bytesEncoding": "hex"
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0xeb2a6f0f62cc7956562dc4e6316b60bdaff6a15affd6431592cb52f1552caa55",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
       },
       "icon": {
         "web3Icons": {
           "name": "xai"
+        }
+      }
+    },
+    {
+      "id": "zetachain",
+      "shortName": "ZetaChain",
+      "fullName": "ZetaChain Mainnet",
+      "aliases": [
+        "evm-7000",
+        "zetachain-mainnet"
+      ],
+      "caip2Id": "eip155:7000",
+      "graphNode": {
+        "protocol": "ethereum"
+      },
+      "explorerUrls": [
+        "https://zetachain.blockscout.com"
+      ],
+      "apiUrls": [
+        {
+          "url": "https://zetachain.blockscout.com/api",
+          "kind": "etherscan"
+        }
+      ],
+      "rpcUrls": [
+        "https://zetachain-mainnet.g.allthatnode.com/archive/evm",
+        "https://zetachain-mainnet.public.blastapi.io"
+      ],
+      "services": {
+        "subgraphs": [
+          "https://api.studio.thegraph.com/deploy"
+        ]
+      },
+      "networkType": "mainnet",
+      "issuanceRewards": false,
+      "nativeToken": "ZETA",
+      "docsUrl": "https://www.zetachain.com/docs",
+      "firehose": {
+        "blockType": "sf.ethereum.type.v2.Block",
+        "evmExtendedModel": true,
+        "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0x60da6194a8e29e0e36c74544037918dd7a3a8a406f8e9f24d37c79623ee69690",
+          "height": 1
+        },
+        "blockFeatures": [
+          "base"
+        ]
+      },
+      "icon": {
+        "web3Icons": {
+          "name": "zeta-chain"
+        }
+      }
+    },
+    {
+      "id": "tron-evm",
+      "shortName": "TRON EVM",
+      "fullName": "TRON EVM Mainnet",
+      "aliases": [
+        "tronevm",
+        "tron-evm-mainnet",
+        "evm-728126428"
+      ],
+      "caip2Id": "eip155:728126428",
+      "graphNode": {
+        "protocol": "ethereum"
+      },
+      "explorerUrls": [
+        "https://tronscan.org"
+      ],
+      "rpcUrls": [
+        "https://api.trongrid.io/jsonrpc",
+        "https://tron.drpc.org",
+        "https://rpc.ankr.com/tron_jsonrpc"
+      ],
+      "relations": [
+        {
+          "kind": "evmOf",
+          "network": "tron"
+        }
+      ],
+      "apiUrls": [
+        {
+          "url": "https://apilist.tronscanapi.com/api",
+          "kind": "other"
+        }
+      ],
+      "networkType": "mainnet",
+      "services": {
+        "subgraphs": [],
+        "sps": [],
+        "firehose": [
+          "mainnet-evm.tron.streamingfast.io:443"
+        ],
+        "substreams": [
+          "mainnet-evm.tron.streamingfast.io:443"
+        ]
+      },
+      "issuanceRewards": false,
+      "nativeToken": "TRX",
+      "docsUrl": "https://developers.tron.network",
+      "firehose": {
+        "blockType": "sf.ethereum.type.v2.Block",
+        "evmExtendedModel": false,
+        "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0x00000000000000001ebf88508a03865c71d452e25f4d51194196a1d22b6653dc",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
+      },
+      "icon": {
+        "web3Icons": {
+          "name": "tron"
+        }
+      }
+    },
+    {
+      "id": "hemi-sepolia",
+      "shortName": "Hemi",
+      "secondName": "Sepolia",
+      "fullName": "Hemi Sepolia",
+      "aliases": [
+        "evm-743111",
+        "hemi-testnet"
+      ],
+      "caip2Id": "eip155:743111",
+      "graphNode": {
+        "protocol": "ethereum"
+      },
+      "explorerUrls": [
+        "https://testnet.explorer.hemi.xyz"
+      ],
+      "rpcUrls": [
+        "https://testnet.rpc.hemi.network/rpc"
+      ],
+      "apiUrls": [
+        {
+          "url": "https://testnet.explorer.hemi.xyz/api",
+          "kind": "etherscan"
+        }
+      ],
+      "services": {
+        "subgraphs": [
+          "https://api.studio.thegraph.com/deploy"
+        ]
+      },
+      "networkType": "testnet",
+      "relations": [
+        {
+          "kind": "testnetOf",
+          "network": "hemi"
+        },
+        {
+          "kind": "l2Of",
+          "network": "sepolia"
+        }
+      ],
+      "issuanceRewards": false,
+      "nativeToken": "ETH",
+      "docsUrl": "https://docs.hemi.xyz",
+      "firehose": {
+        "blockType": "sf.ethereum.type.v2.Block",
+        "evmExtendedModel": false,
+        "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0xc7eef424ae7c339cd0896344c80e136b81246ec5fe7d91a668a09b4c17543194",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
+      },
+      "icon": {
+        "web3Icons": {
+          "name": "hemi"
+        }
+      }
+    },
+    {
+      "id": "katana",
+      "shortName": "Katana",
+      "fullName": "Katana Mainnet",
+      "aliases": [
+        "evm-747474",
+        "katana-mainnet"
+      ],
+      "caip2Id": "eip155:747474",
+      "graphNode": {
+        "protocol": "ethereum"
+      },
+      "services": {
+        "subgraphs": [
+          "https://api.studio.thegraph.com/deploy"
+        ]
+      },
+      "networkType": "mainnet",
+      "relations": [
+        {
+          "kind": "l2Of",
+          "network": "mainnet"
+        }
+      ],
+      "issuanceRewards": false,
+      "nativeToken": "ETH",
+      "firehose": {
+        "blockType": "sf.ethereum.type.v2.Block",
+        "evmExtendedModel": false,
+        "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0x2d28253bc3362fb71336e4f45ba058a24167ef8f43aa2527d5ed9ecfa1d2d3d6",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
+      },
+      "icon": {
+        "web3Icons": {
+          "name": "katana"
+        }
+      }
+    },
+    {
+      "id": "ink-sepolia",
+      "shortName": "Ink",
+      "secondName": "Sepolia",
+      "fullName": "Ink Sepolia",
+      "aliases": [
+        "evm-763373",
+        "ink-testnet"
+      ],
+      "caip2Id": "eip155:763373",
+      "graphNode": {
+        "protocol": "ethereum"
+      },
+      "explorerUrls": [
+        "https://explorer-sepolia.inkonchain.com"
+      ],
+      "apiUrls": [
+        {
+          "url": "https://explorer-sepolia.inkonchain.com/api",
+          "kind": "blockscout"
+        }
+      ],
+      "rpcUrls": [
+        "https://rpc-gel-sepolia.inkonchain.com"
+      ],
+      "services": {
+        "subgraphs": [
+          "https://api.studio.thegraph.com/deploy"
+        ]
+      },
+      "networkType": "testnet",
+      "relations": [
+        {
+          "kind": "testnetOf",
+          "network": "ink"
+        },
+        {
+          "kind": "l2Of",
+          "network": "sepolia"
+        }
+      ],
+      "issuanceRewards": false,
+      "nativeToken": "ETH",
+      "docsUrl": "https://docs.inkonchain.com",
+      "firehose": {
+        "blockType": "sf.ethereum.type.v2.Block",
+        "evmExtendedModel": true,
+        "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0xe5fd5cf0be56af58ad5751b401410d6b7a09d830fa459789746a3d0dd1c79834",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
+      },
+      "icon": {
+        "web3Icons": {
+          "name": "ink"
         }
       }
     },
@@ -3739,11 +6728,15 @@
       ],
       "rpcUrls": [
         "https://rpc.zora.energy",
-        "https://zora.rpc.pinax.network/v1/{PINAX_API_KEY}"
+        "https://zora.rpc.service.pinax.network"
       ],
       "apiUrls": [
         {
-          "url": "https://explorer.zora.energy/api/v2",
+          "url": "https://explorer.zora.energy/api",
+          "kind": "blockscout"
+        },
+        {
+          "url": "https://api.routescan.io/v2/network/mainnet/evm/7777777/etherscan/api",
           "kind": "etherscan"
         }
       ],
@@ -3762,24 +6755,36 @@
           "network": "mainnet"
         }
       ],
-      "issuanceRewards": false,
+      "issuanceRewards": true,
       "nativeToken": "ETH",
       "docsUrl": "https://docs.zora.co",
       "indexerDocsUrls": [
         {
           "url": "https://docs.infradao.com/archive-nodes-101/zora",
-          "description": "Arhchive Nodes 101"
+          "description": "Archive Nodes 101"
         }
       ],
-      "genesis": {
-        "hash": "0x47555a45a1af8d4728ca337a1e48375a83919b1ea16591e070a07388b7364e29",
-        "height": 0
-      },
       "firehose": {
         "blockType": "sf.ethereum.type.v2.Block",
-        "evmExtendedModel": false,
+        "evmExtendedModel": true,
         "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
-        "bytesEncoding": "hex"
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0x47555a45a1af8d4728ca337a1e48375a83919b1ea16591e070a07388b7364e29",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
+      },
+      "icon": {
+        "web3Icons": {
+          "name": "zora",
+          "variants": [
+            "branded",
+            "background"
+          ]
+        }
       }
     },
     {
@@ -3810,18 +6815,22 @@
       ],
       "rpcUrls": [
         "https://rpc-amoy.polygon.technology",
-        "https://amoy.rpc.pinax.network/v1/{PINAX_API_KEY}"
+        "https://amoy.rpc.service.pinax.network"
       ],
       "apiUrls": [
         {
           "url": "https://polygon-amoy.abi.pinax.network/api",
+          "kind": "etherscan"
+        },
+        {
+          "url": "https://api.routescan.io/v2/network/testnet/evm/80002/etherscan/api",
           "kind": "etherscan"
         }
       ],
       "networkType": "testnet",
       "services": {
         "subgraphs": [
-          "https://api.thegraph.com/deploy"
+          "https://api.studio.thegraph.com/deploy"
         ],
         "firehose": [
           "amoy.firehose.pinax.network:443"
@@ -3833,19 +6842,197 @@
       "issuanceRewards": false,
       "nativeToken": "POL",
       "docsUrl": "https://docs.polygon.technology",
-      "genesis": {
-        "hash": "0x7202b2b53c5a0836e773e319d18922cc756dd67432f9a1f65352b61f4406c697",
-        "height": 0
-      },
       "firehose": {
         "blockType": "sf.ethereum.type.v2.Block",
         "evmExtendedModel": true,
         "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
-        "bytesEncoding": "hex"
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0x7202b2b53c5a0836e773e319d18922cc756dd67432f9a1f65352b61f4406c697",
+          "height": 0
+        },
+        "blockFeatures": [
+          "extended"
+        ]
       },
       "icon": {
         "web3Icons": {
-          "name": "polygon-pos"
+          "name": "polygon"
+        }
+      }
+    },
+    {
+      "id": "berachain-bepolia",
+      "shortName": "Berachain",
+      "secondName": "bepolia",
+      "fullName": "Berachain bepolia Testnet",
+      "aliases": [
+        "evm-80069"
+      ],
+      "caip2Id": "eip155:80069",
+      "graphNode": {
+        "protocol": "ethereum"
+      },
+      "rpcUrls": [
+        "https://bepolia.rpc.berachain.com"
+      ],
+      "explorerUrls": [
+        "https://bepolia.beratrail.io"
+      ],
+      "apiUrls": [
+        {
+          "url": "https://api.routescan.io/v2/network/testnet/evm/80069/etherscan/api",
+          "kind": "etherscan"
+        }
+      ],
+      "networkType": "testnet",
+      "relations": [
+        {
+          "kind": "testnetOf",
+          "network": "berachain"
+        }
+      ],
+      "services": {
+        "subgraphs": [
+          "https://api.studio.thegraph.com/deploy"
+        ]
+      },
+      "issuanceRewards": false,
+      "nativeToken": "BERA",
+      "docsUrl": "https://docs.berachain.com",
+      "firehose": {
+        "blockType": "sf.ethereum.type.v2.Block",
+        "evmExtendedModel": true,
+        "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0x0207661de38f0e54ba91c8286096e72486784c79dc6a9681fc486b38335c042f",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
+      },
+      "icon": {
+        "web3Icons": {
+          "name": "berachain"
+        }
+      }
+    },
+    {
+      "id": "berachain",
+      "shortName": "Berachain",
+      "fullName": "Berachain Mainnet",
+      "aliases": [
+        "evm-80094",
+        "berachain-mainnet"
+      ],
+      "caip2Id": "eip155:80094",
+      "graphNode": {
+        "protocol": "ethereum"
+      },
+      "rpcUrls": [
+        "https://rpc.berachain.com",
+        "https://bera.rpc.service.pinax.network"
+      ],
+      "explorerUrls": [
+        "https://berascan.com"
+      ],
+      "apiUrls": [
+        {
+          "url": "https://berachain.abi.pinax.network/api",
+          "kind": "etherscan"
+        },
+        {
+          "url": "https://api.routescan.io/v2/network/mainnet/evm/80094/etherscan/api",
+          "kind": "etherscan"
+        }
+      ],
+      "services": {
+        "subgraphs": [
+          "https://api.studio.thegraph.com/deploy"
+        ],
+        "firehose": [
+          "bera.firehose.pinax.network:443"
+        ],
+        "substreams": [
+          "bera.substreams.pinax.network:443"
+        ]
+      },
+      "networkType": "mainnet",
+      "issuanceRewards": false,
+      "nativeToken": "BERA",
+      "docsUrl": "https://docs.berachain.com",
+      "firehose": {
+        "blockType": "sf.ethereum.type.v2.Block",
+        "evmExtendedModel": true,
+        "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0xd57819422128da1c44339fc7956662378c17e2213e669b427ac91cd11dfcfb38",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
+      },
+      "icon": {
+        "web3Icons": {
+          "name": "berachain"
+        }
+      }
+    },
+    {
+      "id": "joc",
+      "shortName": "JOC",
+      "fullName": "Japan Open Chain Mainnet",
+      "aliases": [
+        "evm-81",
+        "joc-mainnet"
+      ],
+      "caip2Id": "eip155:81",
+      "graphNode": {
+        "protocol": "ethereum"
+      },
+      "explorerUrls": [
+        "https://explorer.japanopenchain.org"
+      ],
+      "rpcUrls": [
+        "https://rpc-1.japanopenchain.org:8545",
+        "https://rpc-2.japanopenchain.org:8545",
+        "https://rpc-3.japanopenchain.org"
+      ],
+      "apiUrls": [
+        {
+          "url": "https://explorer.japanopenchain.org/api",
+          "kind": "etherscan"
+        }
+      ],
+      "services": {
+        "subgraphs": [
+          "https://api.studio.thegraph.com/deploy"
+        ]
+      },
+      "networkType": "mainnet",
+      "issuanceRewards": false,
+      "nativeToken": "JOC",
+      "docsUrl": "https://www.japanopenchain.org/en/developer",
+      "firehose": {
+        "blockType": "sf.ethereum.type.v2.Block",
+        "evmExtendedModel": false,
+        "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0x1b54bfa6846a13aacc57066840ec10d1b74b06870539bbc8a3d1b19bdc566733",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
+      },
+      "icon": {
+        "web3Icons": {
+          "name": "japan-open-chain"
         }
       }
     },
@@ -3866,22 +7053,24 @@
       ],
       "rpcUrls": [
         "https://rpc.blast.io",
-        "https://blast.rpc.pinax.network/v1/{PINAX_API_KEY}",
+        "https://blast.rpc.service.pinax.network",
         "https://rpc.ankr.com/blast"
       ],
       "apiUrls": [
         {
           "url": "https://blast.abi.pinax.network/api",
           "kind": "etherscan"
+        },
+        {
+          "url": "https://blast.blockscout.com/api",
+          "kind": "blockscout"
         }
       ],
       "services": {
         "subgraphs": [
-          "https://api.thegraph.com/deploy"
+          "https://api.studio.thegraph.com/deploy"
         ],
-        "sps": [
-          "https://api.thegraph.com/deploy"
-        ],
+        "sps": [],
         "firehose": [
           "blast.firehose.pinax.network:443"
         ],
@@ -3902,18 +7091,21 @@
       "indexerDocsUrls": [
         {
           "url": "https://docs.infradao.com/archive-nodes-101/blast",
-          "description": "Arhchive Nodes 101"
+          "description": "Archive Nodes 101"
         }
       ],
-      "genesis": {
-        "hash": "0xb689b35ef29d0bec5816938e0e52683c7257d2e325420ea69b739a2be4754b89",
-        "height": 0
-      },
       "firehose": {
         "blockType": "sf.ethereum.type.v2.Block",
         "evmExtendedModel": false,
         "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
-        "bytesEncoding": "hex"
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0xb689b35ef29d0bec5816938e0e52683c7257d2e325420ea69b739a2be4754b89",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
       },
       "icon": {
         "web3Icons": {
@@ -3939,29 +7131,37 @@
       "rpcUrls": [
         "https://public-en.node.kaia.io"
       ],
-      "apiUrls": [],
+      "apiUrls": [
+        {
+          "url": "https://kaia.abi.pinax.network/api",
+          "kind": "etherscan"
+        }
+      ],
       "services": {
         "subgraphs": [
-          "https://api.thegraph.com/deploy"
+          "https://api.studio.thegraph.com/deploy"
         ]
       },
       "networkType": "mainnet",
       "issuanceRewards": false,
       "nativeToken": "KAIA",
       "docsUrl": "https://docs.kaia.io",
-      "genesis": {
-        "hash": "0xc72e5293c3c3ba38ed8ae910f780e4caaa9fb95e79784f7ab74c3c262ea7137e",
-        "height": 0
-      },
       "firehose": {
         "blockType": "sf.ethereum.type.v2.Block",
         "evmExtendedModel": false,
         "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
-        "bytesEncoding": "hex"
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0xc72e5293c3c3ba38ed8ae910f780e4caaa9fb95e79784f7ab74c3c262ea7137e",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
       },
       "icon": {
         "web3Icons": {
-          "name": "klay-token"
+          "name": "kaia"
         }
       }
     },
@@ -3983,21 +7183,23 @@
       "rpcUrls": [
         "https://mainnet.base.org",
         "https://base-rpc.publicnode.com",
-        "https://base.rpc.pinax.network/v1/{PINAX_API_KEY}"
+        "https://base.rpc.service.pinax.network"
       ],
       "apiUrls": [
         {
           "url": "https://base.abi.pinax.network/api",
           "kind": "etherscan"
+        },
+        {
+          "url": "https://base.blockscout.com/api",
+          "kind": "blockscout"
         }
       ],
       "services": {
         "subgraphs": [
-          "https://api.thegraph.com/deploy"
+          "https://api.studio.thegraph.com/deploy"
         ],
-        "sps": [
-          "https://api.thegraph.com/deploy"
-        ],
+        "sps": [],
         "firehose": [
           "base.firehose.pinax.network:443",
           "base-mainnet.streamingfast.io:443"
@@ -4005,6 +7207,9 @@
         "substreams": [
           "base.substreams.pinax.network:443",
           "base-mainnet.streamingfast.io:443"
+        ],
+        "tokenApi": [
+          "https://token-api.thegraph.com"
         ]
       },
       "networkType": "mainnet",
@@ -4020,18 +7225,29 @@
       "indexerDocsUrls": [
         {
           "url": "https://docs.infradao.com/archive-nodes-101/base",
-          "description": "Arhchive Nodes 101"
+          "description": "Archive Nodes 101"
         }
       ],
-      "genesis": {
-        "hash": "0xf712aa9241cc24369b143cf6dce85f0902a9731e70d66818a3a5845b296c73dd",
-        "height": 0
-      },
       "firehose": {
         "blockType": "sf.ethereum.type.v2.Block",
         "evmExtendedModel": true,
         "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
-        "bytesEncoding": "hex"
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0xf712aa9241cc24369b143cf6dce85f0902a9731e70d66818a3a5845b296c73dd",
+          "height": 0
+        },
+        "blockFeatures": [
+          "extended"
+        ]
+      },
+      "tokenApi": {
+        "features": [
+          "tokens",
+          "dexes",
+          "nfts"
+        ],
+        "networkId": "base"
       },
       "icon": {
         "web3Icons": {
@@ -4058,17 +7274,21 @@
       "rpcUrls": [
         "https://sepolia.base.org",
         "https://base-sepolia-rpc.publicnode.com",
-        "https://basesepolia.rpc.pinax.network/v1/{PINAX_API_KEY}"
+        "https://basesepolia.rpc.service.pinax.network"
       ],
       "apiUrls": [
         {
           "url": "https://base-sepolia.abi.pinax.network/api",
           "kind": "etherscan"
+        },
+        {
+          "url": "https://base-sepolia.blockscout.com/api",
+          "kind": "blockscout"
         }
       ],
       "services": {
         "subgraphs": [
-          "https://api.thegraph.com/deploy"
+          "https://api.studio.thegraph.com/deploy"
         ],
         "firehose": [
           "basesepolia.firehose.pinax.network:443"
@@ -4088,22 +7308,77 @@
           "network": "sepolia"
         }
       ],
-      "issuanceRewards": false,
+      "issuanceRewards": true,
       "nativeToken": "ETH",
       "docsUrl": "https://docs.base.org",
-      "genesis": {
-        "hash": "0x0dcc9e089e30b90ddfc55be9a37dd15bc551aeee999d2e2b51414c54eaf934e4",
-        "height": 0
-      },
+      "indexerDocsUrls": [
+        {
+          "url": "https://docs.infradao.com/archive-nodes-101/base-sepolia",
+          "description": "Archive Nodes 101"
+        }
+      ],
       "firehose": {
         "blockType": "sf.ethereum.type.v2.Block",
         "evmExtendedModel": true,
         "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
-        "bytesEncoding": "hex"
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0x0dcc9e089e30b90ddfc55be9a37dd15bc551aeee999d2e2b51414c54eaf934e4",
+          "height": 0
+        },
+        "blockFeatures": [
+          "extended"
+        ]
       },
       "icon": {
         "web3Icons": {
           "name": "base"
+        }
+      }
+    },
+    {
+      "id": "viction",
+      "shortName": "Viction",
+      "fullName": "Viction Mainnet",
+      "aliases": [
+        "evm-88",
+        "viction-mainnet"
+      ],
+      "caip2Id": "eip155:88",
+      "graphNode": {
+        "protocol": "ethereum"
+      },
+      "explorerUrls": [
+        "https://www.vicscan.xyz"
+      ],
+      "rpcUrls": [
+        "https://rpc.viction.xyz"
+      ],
+      "services": {
+        "subgraphs": [
+          "https://api.studio.thegraph.com/deploy"
+        ]
+      },
+      "networkType": "mainnet",
+      "issuanceRewards": false,
+      "nativeToken": "VIC",
+      "docsUrl": "https://docs.viction.xyz",
+      "firehose": {
+        "blockType": "sf.ethereum.type.v2.Block",
+        "evmExtendedModel": true,
+        "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0x9326145f8a2c8c00bbe13afc7d7f3d9c868b5ef39d89f2f4e9390e9720298624",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
+      },
+      "icon": {
+        "web3Icons": {
+          "name": "viction"
         }
       }
     },
@@ -4124,11 +7399,16 @@
         "https://testnet.chiliscan.com"
       ],
       "rpcUrls": [
-        "https://spicy-rpc.chiliz.com"
+        "https://spicy-rpc.chiliz.com",
+        "https://spicy.rpc.service.pinax.network"
       ],
       "apiUrls": [
         {
           "url": "https://spicy-explorer.chiliz.com/api",
+          "kind": "etherscan"
+        },
+        {
+          "url": "https://api.routescan.io/v2/network/testnet/evm/88882/etherscan/api",
           "kind": "etherscan"
         }
       ],
@@ -4141,21 +7421,30 @@
       ],
       "services": {
         "subgraphs": [
-          "https://api.thegraph.com/deploy"
+          "https://api.studio.thegraph.com/deploy"
+        ],
+        "firehose": [
+          "spicy.firehose.pinax.network:443"
+        ],
+        "substreams": [
+          "spicy.substreams.pinax.network:443"
         ]
       },
       "issuanceRewards": false,
       "nativeToken": "CHZ",
       "docsUrl": "https://docs.chiliz.com",
-      "genesis": {
-        "hash": "0x9e0e07ae4ee9b0ef66a4206656677020306259d0b0b845ad3bb6b09fb91485ff",
-        "height": 0
-      },
       "firehose": {
         "blockType": "sf.ethereum.type.v2.Block",
         "evmExtendedModel": false,
         "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
-        "bytesEncoding": "hex"
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0x9e0e07ae4ee9b0ef66a4206656677020306259d0b0b845ad3bb6b09fb91485ff",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
       },
       "icon": {
         "web3Icons": {
@@ -4181,32 +7470,45 @@
       "rpcUrls": [
         "https://rpc.chiliz.com",
         "https://rpc.ankr.com/chiliz",
-        "https://chiliz.rpc.pinax.network/v1/{PINAX_API_KEY}"
+        "https://chiliz.rpc.service.pinax.network"
       ],
       "apiUrls": [
         {
           "url": "https://scan.chiliz.com/api",
+          "kind": "etherscan"
+        },
+        {
+          "url": "https://api.routescan.io/v2/network/mainnet/evm/88888/etherscan/api",
           "kind": "etherscan"
         }
       ],
       "networkType": "mainnet",
       "services": {
         "subgraphs": [
-          "https://api.thegraph.com/deploy"
+          "https://api.studio.thegraph.com/deploy"
+        ],
+        "firehose": [
+          "chiliz.firehose.pinax.network:443"
+        ],
+        "substreams": [
+          "chiliz.substreams.pinax.network:443"
         ]
       },
       "issuanceRewards": false,
       "nativeToken": "CHZ",
       "docsUrl": "https://docs.chiliz.com",
-      "genesis": {
-        "hash": "0xd79fa059ef8cdfcf72676df19e209ee014183a5fa1cf132b2ff9288dbbcf5042",
-        "height": 0
-      },
       "firehose": {
         "blockType": "sf.ethereum.type.v2.Block",
         "evmExtendedModel": false,
         "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
-        "bytesEncoding": "hex"
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0xd79fa059ef8cdfcf72676df19e209ee014183a5fa1cf132b2ff9288dbbcf5042",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
       },
       "icon": {
         "web3Icons": {
@@ -4236,12 +7538,16 @@
       "apiUrls": [
         {
           "url": "https://sepolia.explorer.mode.network/api",
+          "kind": "blockscout"
+        },
+        {
+          "url": "https://api.routescan.io/v2/network/testnet/evm/919/etherscan/api",
           "kind": "etherscan"
         }
       ],
       "services": {
         "subgraphs": [
-          "https://api.thegraph.com/deploy"
+          "https://api.studio.thegraph.com/deploy"
         ]
       },
       "networkType": "testnet",
@@ -4258,15 +7564,18 @@
       "issuanceRewards": false,
       "nativeToken": "ETH",
       "docsUrl": "https://docs.mode.network",
-      "genesis": {
-        "hash": "0x13c352562289a88ed33087a51b6b6c859a27709c8555c9def7cb9757c043acad",
-        "height": 0
-      },
       "firehose": {
         "blockType": "sf.ethereum.type.v2.Block",
         "evmExtendedModel": true,
         "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
-        "bytesEncoding": "hex"
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0x13c352562289a88ed33087a51b6b6c859a27709c8555c9def7cb9757c043acad",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
       },
       "icon": {
         "web3Icons": {
@@ -4293,7 +7602,7 @@
       ],
       "rpcUrls": [
         "https://data-seed-prebsc-1-s1.bnbchain.org:8545",
-        "https://chapel.rpc.pinax.network/v1/{PINAX_API_KEY}"
+        "https://chapel.rpc.service.pinax.network"
       ],
       "apiUrls": [
         {
@@ -4310,7 +7619,7 @@
       ],
       "services": {
         "subgraphs": [
-          "https://api.thegraph.com/deploy"
+          "https://api.studio.thegraph.com/deploy"
         ],
         "firehose": [
           "chapel.firehose.pinax.network:443"
@@ -4322,15 +7631,18 @@
       "issuanceRewards": false,
       "nativeToken": "tBNB",
       "docsUrl": "https://docs.bnbchain.org",
-      "genesis": {
-        "hash": "0x6d3c66c5357ec91d5c43af47e234a939b22557cbb552dc45bebbceeed90fbe34",
-        "height": 0
-      },
       "firehose": {
         "blockType": "sf.ethereum.type.v2.Block",
         "evmExtendedModel": true,
         "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
-        "bytesEncoding": "hex"
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0x6d3c66c5357ec91d5c43af47e234a939b22557cbb552dc45bebbceeed90fbe34",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
       },
       "icon": {
         "web3Icons": {
@@ -4339,62 +7651,60 @@
       }
     },
     {
-      "id": "boba-bnb-testnet",
-      "shortName": "Boba",
-      "secondName": "BNB",
-      "fullName": "Boba BNB Testnet",
+      "id": "lumia",
+      "shortName": "Lumia",
+      "fullName": "Lumia Mainnet",
       "aliases": [
-        "evm-9728",
-        "boba-bsc-testnet"
+        "evm-994873017",
+        "lumia-mainnet"
       ],
-      "caip2Id": "eip155:9728",
+      "caip2Id": "eip155:994873017",
       "graphNode": {
         "protocol": "ethereum"
       },
       "explorerUrls": [
-        "https://bnb.testnet.bobascan.com"
+        "https://lens.lumia.org"
       ],
       "rpcUrls": [
-        "https://testnet.bnb.boba.network"
+        "https://mainnet-rpc.lumia.org"
       ],
       "apiUrls": [
         {
-          "url": "https://api.routescan.io/v2/network/testnet/evm/9728/etherscan/api",
+          "url": "https://explorer.lumia.org/api/",
           "kind": "etherscan"
+        }
+      ],
+      "relations": [
+        {
+          "kind": "l2Of",
+          "network": "mainnet"
         }
       ],
       "services": {
         "subgraphs": [
-          "https://api.thegraph.com/deploy"
+          "https://api.studio.thegraph.com/deploy"
         ]
       },
-      "networkType": "testnet",
-      "relations": [
-        {
-          "kind": "testnetOf",
-          "network": "boba-bnb"
-        },
-        {
-          "kind": "l2Of",
-          "network": "boba-testnet"
-        }
-      ],
+      "networkType": "mainnet",
       "issuanceRewards": false,
-      "nativeToken": "BOBA",
-      "docsUrl": "https://docs.boba.network",
-      "genesis": {
-        "hash": "0x4d26ddc947c7cea924d5ef272c1a5ef40a1dce5ca2cbbaccad59d33f2505a30d",
-        "height": 0
-      },
+      "nativeToken": "LUMIA",
+      "docsUrl": "https://docs.lumia.org",
       "firehose": {
         "blockType": "sf.ethereum.type.v2.Block",
         "evmExtendedModel": false,
         "bufUrl": "https://buf.build/streamingfast/firehose-ethereum",
-        "bytesEncoding": "hex"
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0xbe2fbdd3862a852c02db24f4dcdc8c5eebc74777f393a0119410ed81f6a39120",
+          "height": 0
+        },
+        "blockFeatures": [
+          "base"
+        ]
       },
       "icon": {
         "web3Icons": {
-          "name": "boba"
+          "name": "lumia"
         }
       }
     },
@@ -4407,7 +7717,7 @@
       ],
       "caip2Id": "antelope:1064487b3cd1a897ce03ae5b6a865651",
       "explorerUrls": [
-        "https://wax.bloks.io"
+        "https://eosauthority.com/?network=wax"
       ],
       "rpcUrls": [
         "https://wax.api.eosnation.io"
@@ -4425,14 +7735,19 @@
       "issuanceRewards": false,
       "nativeToken": "WAX",
       "docsUrl": "https://developer.wax.io",
-      "genesis": {
-        "hash": "0x00000002c9a8761a546eeae2d5a0df4586d8d53d5e8c74da1b2f9ee44587f37d",
-        "height": 2
-      },
       "firehose": {
         "blockType": "sf.antelope.type.v1.Block",
         "bufUrl": "https://buf.build/pinax/firehose-antelope",
-        "bytesEncoding": "hex"
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0x00000002c9a8761a546eeae2d5a0df4586d8d53d5e8c74da1b2f9ee44587f37d",
+          "height": 2
+        }
+      },
+      "icon": {
+        "web3Icons": {
+          "name": "wax"
+        }
       }
     },
     {
@@ -4442,7 +7757,7 @@
       "aliases": [],
       "caip2Id": "antelope:1eaa0824707c8c16bd25145493bf062a",
       "explorerUrls": [
-        "https://explorer-test.telos.net"
+        "https://eosauthority.com/?network=telostest"
       ],
       "rpcUrls": [
         "https://telostest.api.eosnation.io"
@@ -4466,14 +7781,14 @@
       "issuanceRewards": false,
       "nativeToken": "TELOS",
       "docsUrl": "https://docs.telos.net",
-      "genesis": {
-        "hash": "0x0000000377dcf185dce2cd5b1ad7e70a7da0a73fc175c47283043791956c70c3",
-        "height": 3
-      },
       "firehose": {
         "blockType": "sf.antelope.type.v1.Block",
         "bufUrl": "https://buf.build/pinax/firehose-antelope",
-        "bytesEncoding": "hex"
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0x0000000377dcf185dce2cd5b1ad7e70a7da0a73fc175c47283043791956c70c3",
+          "height": 3
+        }
       },
       "icon": {
         "web3Icons": {
@@ -4490,7 +7805,7 @@
       ],
       "caip2Id": "antelope:4667b205c6838ef70ff7988f6e8257e8",
       "explorerUrls": [
-        "https://explorer.telos.net"
+        "https://eosauthority.com/?network=telos"
       ],
       "rpcUrls": [
         "https://telos.api.eosnation.io"
@@ -4508,14 +7823,14 @@
       "issuanceRewards": false,
       "nativeToken": "TELOS",
       "docsUrl": "https://docs.telos.net",
-      "genesis": {
-        "hash": "0x000000021d642039071f77a8a2e1eca6cfc0d90f94e7304f0d401bf28f067693",
-        "height": 2
-      },
       "firehose": {
         "blockType": "sf.antelope.type.v1.Block",
         "bufUrl": "https://buf.build/pinax/firehose-antelope",
-        "bytesEncoding": "hex"
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0x000000021d642039071f77a8a2e1eca6cfc0d90f94e7304f0d401bf28f067693",
+          "height": 2
+        }
       },
       "icon": {
         "web3Icons": {
@@ -4533,7 +7848,7 @@
       ],
       "caip2Id": "antelope:5fff1dae8dc8e2fc4d5b23b2c7665c97",
       "explorerUrls": [
-        "https://kylin.bloks.io"
+        "https://eosauthority.com/?network=kylin"
       ],
       "rpcUrls": [
         "https://kylin.api.eosnation.io"
@@ -4557,14 +7872,14 @@
       "issuanceRewards": false,
       "nativeToken": "EOS",
       "docsUrl": "https://docs.eosnetwork.com/docs/latest/quick-start/introduction",
-      "genesis": {
-        "hash": "0x00000002a1ec7ae214b9e43a904b6c010fb1260c9e8a12e5967bdbe451152a07",
-        "height": 2
-      },
       "firehose": {
         "blockType": "sf.antelope.type.v1.Block",
         "bufUrl": "https://buf.build/pinax/firehose-antelope",
-        "bytesEncoding": "hex"
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0x00000002a1ec7ae214b9e43a904b6c010fb1260c9e8a12e5967bdbe451152a07",
+          "height": 2
+        }
       },
       "icon": {
         "web3Icons": {
@@ -4582,7 +7897,7 @@
       ],
       "caip2Id": "antelope:73e4385a2708e6d7048834fbc1079f2f",
       "explorerUrls": [
-        "https://jungle.bloks.io"
+        "https://eosauthority.com/?network=jungle"
       ],
       "rpcUrls": [
         "https://jungle4.api.eosnation.io"
@@ -4606,14 +7921,14 @@
       "issuanceRewards": false,
       "nativeToken": "EOS",
       "docsUrl": "https://jungletestnet.io",
-      "genesis": {
-        "hash": "0x00000002d61d836f51657f886a5bc55b18a731f7eace6565784328fbd051fc90",
-        "height": 2
-      },
       "firehose": {
         "blockType": "sf.antelope.type.v1.Block",
         "bufUrl": "https://buf.build/pinax/firehose-antelope",
-        "bytesEncoding": "hex"
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0x00000002d61d836f51657f886a5bc55b18a731f7eace6565784328fbd051fc90",
+          "height": 2
+        }
       },
       "icon": {
         "web3Icons": {
@@ -4622,15 +7937,58 @@
       }
     },
     {
+      "id": "ultra",
+      "shortName": "Ultra",
+      "fullName": "Ultra Mainnet",
+      "aliases": [
+        "ultra-mainnet"
+      ],
+      "caip2Id": "antelope:a9c481dfbc7d9506dc7e87e9a137c931",
+      "explorerUrls": [
+        "https://explorer.mainnet.ultra.io"
+      ],
+      "rpcUrls": [
+        "https://ultra.api.eosnation.io"
+      ],
+      "apiUrls": [],
+      "networkType": "mainnet",
+      "services": {
+        "firehose": [
+          "ultra.firehose.pinax.network:443"
+        ],
+        "substreams": [
+          "ultra.substreams.pinax.network:443"
+        ]
+      },
+      "issuanceRewards": false,
+      "nativeToken": "UOS",
+      "docsUrl": "https://developers.ultra.io",
+      "firehose": {
+        "blockType": "sf.antelope.type.v1.Block",
+        "bufUrl": "https://buf.build/pinax/firehose-antelope",
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0x00000002e10cbadd0c7491064d13ae89cfbdd734e1f66726861d771af1fcd6e9",
+          "height": 2
+        }
+      },
+      "icon": {
+        "web3Icons": {
+          "name": "ultra"
+        }
+      }
+    },
+    {
       "id": "eos",
       "shortName": "EOS",
       "fullName": "EOS Mainnet",
       "aliases": [
-        "eos-mainnet"
+        "eos-mainnet",
+        "vaulta"
       ],
       "caip2Id": "antelope:aca376f206b8fc25a6ed44dbdc66547c",
       "explorerUrls": [
-        "https://bloks.io"
+        "https://eosauthority.com/?network=eos"
       ],
       "rpcUrls": [
         "https://eos.api.eosnation.io"
@@ -4648,14 +8006,14 @@
       "issuanceRewards": false,
       "nativeToken": "EOS",
       "docsUrl": "https://docs.eosnetwork.com/docs/latest/quick-start/introduction",
-      "genesis": {
-        "hash": "0x0000000267f3e2284b482f3afc2e724be1d6cbc1804532ec62d4e7af47c30693",
-        "height": 2
-      },
       "firehose": {
         "blockType": "sf.antelope.type.v1.Block",
         "bufUrl": "https://buf.build/pinax/firehose-antelope",
-        "bytesEncoding": "hex"
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0x0000000267f3e2284b482f3afc2e724be1d6cbc1804532ec62d4e7af47c30693",
+          "height": 2
+        }
       },
       "icon": {
         "web3Icons": {
@@ -4672,7 +8030,7 @@
       ],
       "caip2Id": "antelope:f16b1833c747c43682f4386fca9cbb32",
       "explorerUrls": [
-        "https://wax-test.bloks.io"
+        "https://eosauthority.com/?network=waxtest"
       ],
       "rpcUrls": [
         "https://waxtest.api.eosnation.io"
@@ -4696,14 +8054,19 @@
       "issuanceRewards": false,
       "nativeToken": "WAX",
       "docsUrl": "https://developer.wax.io",
-      "genesis": {
-        "hash": "0x00000002066113f7023ed907632c404f25c5f0f02034f3b1a22f339c83d78c53",
-        "height": 2
-      },
       "firehose": {
         "blockType": "sf.antelope.type.v1.Block",
         "bufUrl": "https://buf.build/pinax/firehose-antelope",
-        "bytesEncoding": "hex"
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0x00000002066113f7023ed907632c404f25c5f0f02034f3b1a22f339c83d78c53",
+          "height": 2
+        }
+      },
+      "icon": {
+        "web3Icons": {
+          "name": "wax"
+        }
       }
     },
     {
@@ -4721,15 +8084,11 @@
       "apiUrls": [],
       "networkType": "mainnet",
       "graphNode": {
-        "protocol": "arweave"
+        "protocol": "arweave",
+        "deprecatedAt": "2025-05-28T00:00:00Z"
       },
       "services": {
-        "subgraphs": [
-          "https://api.thegraph.com/deploy"
-        ],
-        "sps": [
-          "https://api.thegraph.com/deploy"
-        ],
+        "sps": [],
         "firehose": [
           "arweave.firehose.pinax.network:443"
         ],
@@ -4740,14 +8099,14 @@
       "issuanceRewards": false,
       "nativeToken": "AR",
       "docsUrl": "https://docs.arweave.org/developers",
-      "genesis": {
-        "hash": "0xef0214ecaa252020230a5325719dfc2d9cec86123bc46926dad0c2251ed6be17b7112528dbe678fb2d31d6e6a0951244",
-        "height": 0
-      },
       "firehose": {
         "blockType": "sf.arweave.type.v1.Block",
         "bufUrl": "https://buf.build/pinax/firehose-arweave",
-        "bytesEncoding": "hex"
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0xef0214ecaa252020230a5325719dfc2d9cec86123bc46926dad0c2251ed6be17b7112528dbe678fb2d31d6e6a0951244",
+          "height": 0
+        }
       },
       "icon": {
         "web3Icons": {
@@ -4758,7 +8117,7 @@
     {
       "id": "mainnet-cl",
       "shortName": "Ethereum Beacon",
-      "fullName": "Ethereum Consensus Layer Chain",
+      "fullName": "Ethereum Consensus Layer",
       "aliases": [
         "mainnet-beacon",
         "eth-cl",
@@ -4768,7 +8127,7 @@
       "explorerUrls": [],
       "rpcUrls": [],
       "apiUrls": [],
-      "networkType": "mainnet",
+      "networkType": "beacon",
       "relations": [
         {
           "kind": "beaconOf",
@@ -4786,14 +8145,14 @@
       "issuanceRewards": false,
       "nativeToken": "ETH",
       "docsUrl": "https://ethereum.org/en/developers/docs/consensus-mechanisms",
-      "genesis": {
-        "hash": "0x4d611d5b93fdab69013a7f0a2f961caca0c853f87cfe9595fe50038163079360",
-        "height": 0
-      },
       "firehose": {
         "blockType": "sf.beacon.type.v1.Block",
         "bufUrl": "https://buf.build/pinax/firehose-beacon",
-        "bytesEncoding": "0xhex"
+        "bytesEncoding": "0xhex",
+        "firstStreamableBlock": {
+          "id": "0x4d611d5b93fdab69013a7f0a2f961caca0c853f87cfe9595fe50038163079360",
+          "height": 0
+        }
       },
       "icon": {
         "web3Icons": {
@@ -4802,10 +8161,97 @@
       }
     },
     {
+      "id": "gnosis-cl",
+      "shortName": "Gnosis Beacon",
+      "fullName": "Gnosis Consensus Layer",
+      "aliases": [
+        "gnosis-beacon"
+      ],
+      "caip2Id": "beacon:100",
+      "explorerUrls": [],
+      "rpcUrls": [],
+      "apiUrls": [],
+      "networkType": "beacon",
+      "relations": [
+        {
+          "kind": "beaconOf",
+          "network": "gnosis"
+        }
+      ],
+      "services": {
+        "firehose": [
+          "gnosis-cl.firehose.pinax.network:443"
+        ],
+        "substreams": [
+          "gnosis-cl.substreams.pinax.network:443"
+        ]
+      },
+      "issuanceRewards": false,
+      "nativeToken": "XDAI",
+      "docsUrl": "https://ethereum.org/en/developers/docs/consensus-mechanisms",
+      "firehose": {
+        "blockType": "sf.beacon.type.v1.Block",
+        "bufUrl": "https://buf.build/pinax/firehose-beacon",
+        "bytesEncoding": "0xhex",
+        "firstStreamableBlock": {
+          "id": "0x23564cd15ac0b90ed72cbc78ffd5e35e309816c0cca5ad28390bd9892e846a75",
+          "height": 0
+        }
+      },
+      "icon": {
+        "web3Icons": {
+          "name": "gnosis"
+        }
+      }
+    },
+    {
+      "id": "gnosis-chiado-cl",
+      "shortName": "Chiado Beacon",
+      "fullName": "Gnosis Chiado Consensus Layer",
+      "aliases": [
+        "gnosis-chiado-beacon"
+      ],
+      "caip2Id": "beacon:10200",
+      "explorerUrls": [],
+      "rpcUrls": [],
+      "apiUrls": [],
+      "networkType": "beacon",
+      "relations": [
+        {
+          "kind": "beaconOf",
+          "network": "gnosis-chiado"
+        }
+      ],
+      "services": {
+        "firehose": [
+          "chiado-cl.firehose.pinax.network:443"
+        ],
+        "substreams": [
+          "chiado-cl.substreams.pinax.network:443"
+        ]
+      },
+      "issuanceRewards": false,
+      "nativeToken": "XDAI",
+      "docsUrl": "https://ethereum.org/en/developers/docs/consensus-mechanisms",
+      "firehose": {
+        "blockType": "sf.beacon.type.v1.Block",
+        "bufUrl": "https://buf.build/pinax/firehose-beacon",
+        "bytesEncoding": "0xhex",
+        "firstStreamableBlock": {
+          "id": "0xf227cf50c05b1aa570ce4f8ee00c71f11c63d05b297ad3a0e7a05d341c333381",
+          "height": 0
+        }
+      },
+      "icon": {
+        "web3Icons": {
+          "name": "gnosis"
+        }
+      }
+    },
+    {
       "id": "sepolia-cl",
-      "shortName": "Ethereum Beacon",
-      "secondName": "Sepolia",
-      "fullName": "Ethereum Sepolia Consensus Layer Chain",
+      "shortName": "Sepolia Beacon",
+      "fullName": "Ethereum Sepolia Consensus Layer",
       "aliases": [
         "sepolia-beacon"
       ],
@@ -4813,7 +8259,7 @@
       "explorerUrls": [],
       "rpcUrls": [],
       "apiUrls": [],
-      "networkType": "mainnet",
+      "networkType": "beacon",
       "relations": [
         {
           "kind": "beaconOf",
@@ -4822,23 +8268,23 @@
       ],
       "services": {
         "firehose": [
-          "holesky-cl.firehose.pinax.network:443"
+          "sepolia-cl.firehose.pinax.network:443"
         ],
         "substreams": [
-          "holesky-cl.substreams.pinax.network:443"
+          "sepolia-cl.substreams.pinax.network:443"
         ]
       },
       "issuanceRewards": false,
       "nativeToken": "ETH",
       "docsUrl": "https://ethereum.org/en/developers/docs/consensus-mechanisms",
-      "genesis": {
-        "hash": "0xfb9b64fe445f76696407e1e3cc390371edff147bf712db86db6197d4b31ede43",
-        "height": 0
-      },
       "firehose": {
         "blockType": "sf.beacon.type.v1.Block",
         "bufUrl": "https://buf.build/pinax/firehose-beacon",
-        "bytesEncoding": "0xhex"
+        "bytesEncoding": "0xhex",
+        "firstStreamableBlock": {
+          "id": "0xfb9b64fe445f76696407e1e3cc390371edff147bf712db86db6197d4b31ede43",
+          "height": 0
+        }
       },
       "icon": {
         "web3Icons": {
@@ -4848,9 +8294,8 @@
     },
     {
       "id": "holesky-cl",
-      "shortName": "Ethereum Beacon",
-      "secondName": "Holesky",
-      "fullName": "Ethereum Holesky Consensus Layer Chain",
+      "shortName": "Holesky Beacon",
+      "fullName": "Ethereum Holesky Consensus Layer",
       "aliases": [
         "holesky-beacon"
       ],
@@ -4858,7 +8303,7 @@
       "explorerUrls": [],
       "rpcUrls": [],
       "apiUrls": [],
-      "networkType": "mainnet",
+      "networkType": "beacon",
       "relations": [
         {
           "kind": "beaconOf",
@@ -4876,14 +8321,58 @@
       "issuanceRewards": false,
       "nativeToken": "ETH",
       "docsUrl": "https://ethereum.org/en/developers/docs/consensus-mechanisms",
-      "genesis": {
-        "hash": "0xab09edd9380f8451c3ff5c809821174a36dce606fea8b5ea35ea936915dbf889",
-        "height": 0
-      },
       "firehose": {
         "blockType": "sf.beacon.type.v1.Block",
         "bufUrl": "https://buf.build/pinax/firehose-beacon",
-        "bytesEncoding": "0xhex"
+        "bytesEncoding": "0xhex",
+        "firstStreamableBlock": {
+          "id": "0xab09edd9380f8451c3ff5c809821174a36dce606fea8b5ea35ea936915dbf889",
+          "height": 0
+        }
+      },
+      "icon": {
+        "web3Icons": {
+          "name": "ethereum"
+        }
+      }
+    },
+    {
+      "id": "hoodi-cl",
+      "shortName": "Hoodi Beacon",
+      "fullName": "Ethereum Hoodi Consensus Layer",
+      "aliases": [
+        "hoodi-beacon"
+      ],
+      "caip2Id": "beacon:560048",
+      "explorerUrls": [],
+      "rpcUrls": [],
+      "apiUrls": [],
+      "networkType": "beacon",
+      "relations": [
+        {
+          "kind": "beaconOf",
+          "network": "hoodi"
+        }
+      ],
+      "services": {
+        "firehose": [
+          "hoodi-cl.firehose.pinax.network:443"
+        ],
+        "substreams": [
+          "hoodi-cl.substreams.pinax.network:443"
+        ]
+      },
+      "issuanceRewards": false,
+      "nativeToken": "ETH",
+      "docsUrl": "https://ethereum.org/en/developers/docs/consensus-mechanisms",
+      "firehose": {
+        "blockType": "sf.beacon.type.v1.Block",
+        "bufUrl": "https://buf.build/pinax/firehose-beacon",
+        "bytesEncoding": "0xhex",
+        "firstStreamableBlock": {
+          "id": "0x376450cd7fb9f05ade82a7f88565ac57af449ac696b1a6ac5cc7dac7d467b7d6",
+          "height": 0
+        }
       },
       "icon": {
         "web3Icons": {
@@ -4896,7 +8385,8 @@
       "shortName": "Bitcoin",
       "fullName": "Bitcoin Mainnet",
       "aliases": [
-        "bitcoin"
+        "bitcoin",
+        "btc-mainnet"
       ],
       "caip2Id": "bip122:000000000019d6689c085ae165831e93",
       "explorerUrls": [
@@ -4909,11 +8399,9 @@
       "networkType": "mainnet",
       "services": {
         "subgraphs": [
-          "https://api.thegraph.com/deploy"
+          "https://api.studio.thegraph.com/deploy"
         ],
-        "sps": [
-          "https://api.thegraph.com/deploy"
-        ],
+        "sps": [],
         "firehose": [
           "bitcoin.firehose.pinax.network:443",
           "mainnet.btc.streamingfast.io:443"
@@ -4926,18 +8414,61 @@
       "issuanceRewards": false,
       "nativeToken": "BTC",
       "docsUrl": "https://developer.bitcoin.org",
-      "genesis": {
-        "hash": "0x000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f",
-        "height": 0
-      },
       "firehose": {
         "blockType": "sf.bitcoin.type.v1.Block",
         "bufUrl": "https://buf.build/streamingfast/firehose-bitcoin",
-        "bytesEncoding": "hex"
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0x000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f",
+          "height": 0
+        }
       },
       "icon": {
         "web3Icons": {
           "name": "bitcoin"
+        }
+      }
+    },
+    {
+      "id": "litecoin",
+      "shortName": "Litecoin",
+      "fullName": "Litecoin Mainnet",
+      "aliases": [
+        "ltc",
+        "litecoin-mainnet"
+      ],
+      "caip2Id": "bip122:12a765e31ffd4059bada1e25190f6e98",
+      "explorerUrls": [
+        "https://blockexplorer.one/litecoin/mainnet"
+      ],
+      "rpcUrls": [
+        "https://litecoin-mainnet.gateway.tatum.io"
+      ],
+      "apiUrls": [],
+      "networkType": "mainnet",
+      "services": {
+        "firehose": [
+          "litecoin.firehose.pinax.network:443"
+        ],
+        "substreams": [
+          "litecoin.substreams.pinax.network:443"
+        ]
+      },
+      "issuanceRewards": false,
+      "nativeToken": "LTC",
+      "docsUrl": "https://litecoin.info/docs",
+      "firehose": {
+        "blockType": "sf.bitcoin.type.v1.Block",
+        "bufUrl": "https://buf.build/streamingfast/firehose-bitcoin",
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0x12a765e31ffd4059bada1e25190f6e98c99d9714d334efa41a195a7e7e04bfe2",
+          "height": 0
+        }
+      },
+      "icon": {
+        "web3Icons": {
+          "name": "litecoin"
         }
       }
     },
@@ -4957,7 +8488,8 @@
       "apiUrls": [],
       "networkType": "mainnet",
       "graphNode": {
-        "protocol": "cosmos"
+        "protocol": "cosmos",
+        "deprecatedAt": "2025-04-23T00:00:00Z"
       },
       "services": {
         "firehose": [
@@ -4970,14 +8502,14 @@
       "issuanceRewards": false,
       "nativeToken": "INJ",
       "docsUrl": "https://docs.injective.network",
-      "genesis": {
-        "hash": "0x24c9714291a999b952859ee02ec9b233394fe743b07ea3578d432a4a2707b6af",
-        "height": 1
-      },
       "firehose": {
         "blockType": "sf.cosmos.type.v2.Block",
         "bufUrl": "https://buf.build/streamingfast/firehose-cosmos",
-        "bytesEncoding": "hex"
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0x24c9714291a999b952859ee02ec9b233394fe743b07ea3578d432a4a2707b6af",
+          "height": 1
+        }
       },
       "icon": {
         "web3Icons": {
@@ -5000,7 +8532,8 @@
       "apiUrls": [],
       "networkType": "testnet",
       "graphNode": {
-        "protocol": "cosmos"
+        "protocol": "cosmos",
+        "deprecatedAt": "2025-04-23T00:00:00Z"
       },
       "relations": [
         {
@@ -5019,14 +8552,14 @@
       "issuanceRewards": false,
       "nativeToken": "INJ",
       "docsUrl": "https://docs.injective.network",
-      "genesis": {
-        "hash": "0xa9effb99c7bc3ba8c18a487ffffd800c137bc2b2f47f73c350f3ca27077044a1",
-        "height": 37368800
-      },
       "firehose": {
         "blockType": "sf.cosmos.type.v2.Block",
         "bufUrl": "https://buf.build/streamingfast/firehose-cosmos",
-        "bytesEncoding": "hex"
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0x7d5eabf8f6b38dd6d0135d8e16b778fa5bc9eb47b9c733f6c9563727d75ff3a9",
+          "height": 73538100
+        }
       },
       "icon": {
         "web3Icons": {
@@ -5052,7 +8585,8 @@
       "apiUrls": [],
       "networkType": "mainnet",
       "graphNode": {
-        "protocol": "cosmos"
+        "protocol": "cosmos",
+        "deprecatedAt": "2025-04-23T00:00:00Z"
       },
       "services": {
         "firehose": [
@@ -5065,14 +8599,19 @@
       "issuanceRewards": false,
       "nativeToken": "OM",
       "docsUrl": "https://docs.mantrachain.io",
-      "genesis": {
-        "hash": "0x0d56d4b442c9628cb5679a04dbb8085920c64a4737fe50b8574c4d3a37ab2141",
-        "height": 1
-      },
       "firehose": {
         "blockType": "sf.cosmos.type.v2.Block",
         "bufUrl": "https://buf.build/streamingfast/firehose-cosmos",
-        "bytesEncoding": "hex"
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0x0d56d4b442c9628cb5679a04dbb8085920c64a4737fe50b8574c4d3a37ab2141",
+          "height": 1
+        }
+      },
+      "icon": {
+        "web3Icons": {
+          "name": "mantra"
+        }
       }
     },
     {
@@ -5099,7 +8638,8 @@
         }
       ],
       "graphNode": {
-        "protocol": "cosmos"
+        "protocol": "cosmos",
+        "deprecatedAt": "2025-04-23T00:00:00Z"
       },
       "services": {
         "firehose": [
@@ -5112,91 +8652,19 @@
       "issuanceRewards": false,
       "nativeToken": "OM",
       "docsUrl": "https://docs.mantrachain.io",
-      "genesis": {
-        "hash": "0x2701f72ef3e2242e27244b2dfa895ad212fc07de71599a0af2fe2410d93bc7bb",
-        "height": 1
-      },
       "firehose": {
         "blockType": "sf.cosmos.type.v2.Block",
         "bufUrl": "https://buf.build/streamingfast/firehose-cosmos",
-        "bytesEncoding": "hex"
-      }
-    },
-    {
-      "id": "vara-mainnet",
-      "shortName": "Vara",
-      "fullName": "Vara Mainnet",
-      "aliases": [
-        "vara"
-      ],
-      "caip2Id": "gear:vara-mainnet",
-      "explorerUrls": [
-        "https://vara.subscan.io"
-      ],
-      "rpcUrls": [],
-      "apiUrls": [
-        {
-          "url": "https://vara.api.subscan.io/api",
-          "kind": "subscan"
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0xf4e9183911bbc59c472602cc83f06d8d335fc8f40c604a1a1adc0b7593403a84",
+          "height": 1
         }
-      ],
-      "networkType": "mainnet",
-      "services": {
-        "firehose": [
-          "mainnet.vara.streamingfast.io:443"
-        ],
-        "substreams": [
-          "mainnet.vara.streamingfast.io:443"
-        ]
       },
-      "issuanceRewards": false,
-      "nativeToken": "VARA",
-      "docsUrl": "https://wiki.vara.network",
-      "genesis": {
-        "hash": "0xfe1b4c55fd4d668101126434206571a7838a8b6b93a6d1b95d607e78e6c53763",
-        "height": 0
-      },
-      "firehose": {
-        "blockType": "sf.gear.type.v1.Block",
-        "bufUrl": "https://buf.build/streamingfast/firehose-gear",
-        "bytesEncoding": "hex"
-      }
-    },
-    {
-      "id": "vara-testnet",
-      "shortName": "Vara",
-      "fullName": "Vara Testnet",
-      "aliases": [],
-      "caip2Id": "gear:vara-testnet",
-      "relations": [
-        {
-          "kind": "testnetOf",
-          "network": "vara-mainnet"
+      "icon": {
+        "web3Icons": {
+          "name": "mantra"
         }
-      ],
-      "explorerUrls": [],
-      "rpcUrls": [],
-      "apiUrls": [],
-      "networkType": "testnet",
-      "services": {
-        "firehose": [
-          "testnet.vara.streamingfast.io:443"
-        ],
-        "substreams": [
-          "testnet.vara.streamingfast.io:443"
-        ]
-      },
-      "issuanceRewards": false,
-      "nativeToken": "VARA",
-      "docsUrl": "https://wiki.vara.network",
-      "genesis": {
-        "hash": "0x525639f713f397dcf839bd022cd821f367ebcf179de7b9253531f8adbe5436d6",
-        "height": 0
-      },
-      "firehose": {
-        "blockType": "sf.gear.type.v1.Block",
-        "bufUrl": "https://buf.build/streamingfast/firehose-gear",
-        "bytesEncoding": "hex"
       }
     },
     {
@@ -5220,11 +8688,9 @@
       },
       "services": {
         "subgraphs": [
-          "https://api.thegraph.com/deploy"
+          "https://api.studio.thegraph.com/deploy"
         ],
-        "sps": [
-          "https://api.thegraph.com/deploy"
-        ],
+        "sps": [],
         "firehose": [
           "near.firehose.pinax.network:443",
           "mainnet.near.streamingfast.io:443"
@@ -5237,14 +8703,14 @@
       "issuanceRewards": false,
       "nativeToken": "NEAR",
       "docsUrl": "https://docs.near.org",
-      "genesis": {
-        "hash": "0xa7110b9052e1be68f7fa8bb4065bf54e731205801878e708db7464ec4b9b8014",
-        "height": 9820214
-      },
       "firehose": {
         "blockType": "sf.near.type.v1.Block",
         "bufUrl": "https://buf.build/streamingfast/firehose-near",
-        "bytesEncoding": "hex"
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0xc6fdf91c8e82f8f917cc1975e9de1c64be11899e321dfdf5febcfbb7313f1486",
+          "height": 9820210
+        }
       },
       "icon": {
         "web3Icons": {
@@ -5277,31 +8743,27 @@
       ],
       "services": {
         "subgraphs": [
-          "https://api.thegraph.com/deploy"
+          "https://api.studio.thegraph.com/deploy"
         ],
-        "sps": [
-          "https://api.thegraph.com/deploy"
-        ],
+        "sps": [],
         "firehose": [
-          "neartest.firehose.pinax.network:443",
-          "testnet.near.streamingfast.io:443"
+          "neartest.firehose.pinax.network:443"
         ],
         "substreams": [
-          "neartest.substreams.pinax.network:443",
-          "testnet.near.streamingfast.io:443"
+          "neartest.substreams.pinax.network:443"
         ]
       },
       "issuanceRewards": false,
       "nativeToken": "NEAR",
       "docsUrl": "https://docs.near.org",
-      "genesis": {
-        "hash": "0x09d69c8ba4f319f8e78d0b701f0c1f763cc0d920551bfbd00072d5f56016d853",
-        "height": 42376923
-      },
       "firehose": {
         "blockType": "sf.near.type.v1.Block",
         "bufUrl": "https://buf.build/streamingfast/firehose-near",
-        "bytesEncoding": "hex"
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0xd784da5a9e5e66668516c19a8095448fc54a22a28971dc330f0099df94379410",
+          "height": 42376888
+        }
       },
       "icon": {
         "web3Icons": {
@@ -5315,7 +8777,9 @@
       "fullName": "Solana Mainnet",
       "aliases": [
         "solana-mainnet",
-        "solana"
+        "solana",
+        "solana-beta",
+        "sol-mainnet"
       ],
       "caip2Id": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
       "explorerUrls": [
@@ -5328,30 +8792,66 @@
       "apiUrls": [],
       "networkType": "mainnet",
       "services": {
-        "subgraphs": [
-          "https://api.thegraph.com/deploy"
-        ],
-        "sps": [
-          "https://api.thegraph.com/deploy"
-        ],
+        "subgraphs": [],
+        "sps": [],
         "firehose": [
-          "mainnet.sol.streamingfast.io:443"
+          "mainnet.sol.streamingfast.io:443",
+          "solana.firehose.pinax.network:443"
         ],
         "substreams": [
-          "mainnet.sol.streamingfast.io:443"
+          "mainnet.sol.streamingfast.io:443",
+          "solana.substreams.pinax.network:443"
         ]
       },
       "issuanceRewards": false,
       "nativeToken": "SOL",
       "docsUrl": "https://solana.com/docs",
-      "genesis": {
-        "hash": "4sGjMW1sUnHzSxGspuhpqLDx6wiyjNtZAMdL4VZHirAn",
-        "height": 0
-      },
       "firehose": {
         "blockType": "sf.solana.type.v1.Block",
         "bufUrl": "https://buf.build/streamingfast/firehose-solana",
-        "bytesEncoding": "base58"
+        "bytesEncoding": "base58",
+        "firstStreamableBlock": {
+          "id": "4sGjMW1sUnHzSxGspuhpqLDx6wiyjNtZAMdL4VZHirAn",
+          "height": 0
+        }
+      },
+      "icon": {
+        "web3Icons": {
+          "name": "solana"
+        }
+      }
+    },
+    {
+      "id": "solana-accounts",
+      "shortName": "Solana Accounts",
+      "fullName": "Solana Accounts",
+      "aliases": [
+        "solana-accounts-mainnet"
+      ],
+      "caip2Id": "solana:Accounts",
+      "explorerUrls": [],
+      "rpcUrls": [],
+      "apiUrls": [],
+      "networkType": "mainnet",
+      "services": {
+        "subgraphs": [],
+        "sps": [],
+        "firehose": [],
+        "substreams": [
+          "accounts.mainnet.sol.streamingfast.io:443"
+        ]
+      },
+      "issuanceRewards": false,
+      "nativeToken": "SOL",
+      "docsUrl": "https://www.streamingfast.io/solana-data-stream",
+      "firehose": {
+        "blockType": "sf.solana.type.v1.AccountBlock",
+        "bufUrl": "https://buf.build/streamingfast/firehose-solana",
+        "bytesEncoding": "base58",
+        "firstStreamableBlock": {
+          "id": "4sGjMW1sUnHzSxGspuhpqLDx6wiyjNtZAMdL4VZHirAn",
+          "height": 0
+        }
       },
       "icon": {
         "web3Icons": {
@@ -5380,34 +8880,84 @@
         }
       ],
       "services": {
-        "subgraphs": [
-          "https://api.thegraph.com/deploy"
-        ],
-        "sps": [
-          "https://api.thegraph.com/deploy"
-        ],
+        "subgraphs": [],
+        "sps": [],
         "firehose": [
-          "devnet.sol.streamingfast.io:443"
+          "devnet.sol.streamingfast.io:443",
+          "soldev.firehose.pinax.network:443"
         ],
         "substreams": [
-          "devnet.sol.streamingfast.io:443"
+          "devnet.sol.streamingfast.io:443",
+          "soldev.substreams.pinax.network:443"
         ]
       },
       "issuanceRewards": false,
       "nativeToken": "SOL",
       "docsUrl": "https://solana.com/docs",
-      "genesis": {
-        "hash": "4D2M7ehkYzBJNsL9GYvQXKj7sFaJGGyZMvK5hC8BQvS8",
-        "height": 300000000
-      },
       "firehose": {
         "blockType": "sf.solana.type.v1.Block",
         "bufUrl": "https://buf.build/streamingfast/firehose-solana",
-        "bytesEncoding": "base58"
+        "bytesEncoding": "base58",
+        "firstStreamableBlock": {
+          "id": "B2Ano6cfDxb1ce3WXVM3VmkVGj3NPGB5ag95S46S3cpE",
+          "height": 325312361
+        }
       },
       "icon": {
         "web3Icons": {
           "name": "solana"
+        }
+      }
+    },
+    {
+      "id": "bnb-svm",
+      "shortName": "svmBNB",
+      "fullName": "svmBNB Mainnet",
+      "aliases": [
+        "bnb-svm-mainnet"
+      ],
+      "caip2Id": "solana:FRXwreefVunjoWykEhH42cxRMdyP2FuZ",
+      "explorerUrls": [
+        "https://explorer.svmbnbmainnet.soo.network"
+      ],
+      "rpcUrls": [
+        "https://rpc.svmbnbmainnet.soo.network/rpc"
+      ],
+      "apiUrls": [],
+      "networkType": "mainnet",
+      "relations": [
+        {
+          "kind": "l2Of",
+          "network": "bsc"
+        },
+        {
+          "kind": "svmOf",
+          "network": "bsc"
+        }
+      ],
+      "services": {
+        "firehose": [
+          "svmbnb.firehose.pinax.network:443"
+        ],
+        "substreams": [
+          "svmbnb.substreams.pinax.network:443"
+        ]
+      },
+      "issuanceRewards": false,
+      "nativeToken": "BNB",
+      "docsUrl": "https://docs.soo.network",
+      "firehose": {
+        "blockType": "sf.solana.type.v1.Block",
+        "bufUrl": "https://buf.build/streamingfast/firehose-solana",
+        "bytesEncoding": "base58",
+        "firstStreamableBlock": {
+          "id": "FRXwreefVunjoWykEhH42cxRMdyP2FuZFwqofmX1LRDx",
+          "height": 1
+        }
+      },
+      "icon": {
+        "web3Icons": {
+          "name": "binance-smart-chain"
         }
       }
     },
@@ -5433,24 +8983,21 @@
       ],
       "rpcUrls": [
         "https://starknet-mainnet.public.blastapi.io",
-        "https://starknet.rpc.pinax.network/v1/{PINAX_API_KEY}"
+        "https://starknet.rpc.service.pinax.network"
       ],
       "apiUrls": [],
       "networkType": "mainnet",
       "services": {
         "subgraphs": [
-          "https://api.thegraph.com/deploy"
+          "https://api.studio.thegraph.com/deploy"
         ],
-        "sps": [
-          "https://api.thegraph.com/deploy"
-        ],
+        "sps": [],
         "firehose": [
-          "mainnet.starknet.streamingfast.io:443",
           "starknet.firehose.pinax.network:443"
         ],
         "substreams": [
-          "mainnet.starknet.streamingfast.io:443",
-          "starknet.substreams.pinax.network:443"
+          "starknet.substreams.pinax.network:443",
+          "mainnet.starknet.streamingfast.io:443"
         ]
       },
       "issuanceRewards": false,
@@ -5459,17 +9006,17 @@
       "indexerDocsUrls": [
         {
           "url": "https://docs.infradao.com/archive-nodes-101/starknet",
-          "description": "Arhchive Nodes 101"
+          "description": "Archive Nodes 101"
         }
       ],
-      "genesis": {
-        "hash": "0x47c3637b57c2b079b93c61539950c17e868a28f46cdef28f88521067f21e943",
-        "height": 0
-      },
       "firehose": {
         "blockType": "sf.starknet.type.v1.Block",
         "bufUrl": "https://buf.build/streamingfast/firehose-starknet",
-        "bytesEncoding": "0xhex"
+        "bytesEncoding": "0xhex",
+        "firstStreamableBlock": {
+          "id": "0x47c3637b57c2b079b93c61539950c17e868a28f46cdef28f88521067f21e943",
+          "height": 0
+        }
       },
       "icon": {
         "web3Icons": {
@@ -5504,33 +9051,177 @@
       ],
       "rpcUrls": [
         "https://starknet-sepolia.public.blastapi.io",
-        "https://starksepolia.rpc.pinax.network/v1/{PINAX_API_KEY}"
+        "https://starksepolia.rpc.service.pinax.network"
       ],
       "apiUrls": [],
       "networkType": "testnet",
       "services": {
+        "subgraphs": [
+          "https://api.studio.thegraph.com/deploy"
+        ],
+        "sps": [],
         "firehose": [
           "starksepolia.firehose.pinax.network:443"
         ],
         "substreams": [
-          "starksepolia.substreams.pinax.network:443"
+          "starksepolia.substreams.pinax.network:443",
+          "testnet.starknet.streamingfast.io:443"
         ]
       },
       "issuanceRewards": false,
       "nativeToken": "STRK",
       "docsUrl": "https://docs.starknet.io",
-      "genesis": {
-        "hash": "0x05c627d4aeb51280058bed93c7889bce78114d63baad1be0f0aeb32496d5f19c",
-        "height": 0
-      },
       "firehose": {
         "blockType": "sf.starknet.type.v1.Block",
         "bufUrl": "https://buf.build/streamingfast/firehose-starknet",
-        "bytesEncoding": "0xhex"
+        "bytesEncoding": "0xhex",
+        "firstStreamableBlock": {
+          "id": "0x5c627d4aeb51280058bed93c7889bce78114d63baad1be0f0aeb32496d5f19c",
+          "height": 0
+        }
       },
       "icon": {
         "web3Icons": {
           "name": "starknet"
+        }
+      }
+    },
+    {
+      "id": "stellar",
+      "shortName": "Stellar",
+      "fullName": "Stellar Mainnet",
+      "aliases": [
+        "stellar-mainnet"
+      ],
+      "caip2Id": "stellar:pubnet",
+      "explorerUrls": [
+        "https://stellarchain.io"
+      ],
+      "rpcUrls": [
+        "https://horizon.stellar.org"
+      ],
+      "networkType": "mainnet",
+      "services": {
+        "subgraphs": [],
+        "sps": [],
+        "firehose": [
+          "mainnet.stellar.streamingfast.io:443"
+        ],
+        "substreams": [
+          "mainnet.stellar.streamingfast.io:443"
+        ]
+      },
+      "issuanceRewards": false,
+      "nativeToken": "XLM",
+      "docsUrl": "https://developers.stellar.org",
+      "firehose": {
+        "blockType": "sf.stellar.type.v1.Block",
+        "bufUrl": "https://buf.build/streamingfast/firehose-stellar",
+        "bytesEncoding": "base64",
+        "firstStreamableBlock": {
+          "id": "0x84e2b18c296badee2a6c30347911f2b5a4323e1ecb3c8986235e1fdc322dadbe",
+          "height": 55411000
+        }
+      },
+      "icon": {
+        "web3Icons": {
+          "name": "stellar"
+        }
+      }
+    },
+    {
+      "id": "stellar-testnet",
+      "shortName": "Stellar",
+      "fullName": "Stellar Testnet",
+      "aliases": [
+        "stellar-soroban"
+      ],
+      "caip2Id": "stellar:testnet",
+      "explorerUrls": [
+        "https://testnet.stellarchain.io"
+      ],
+      "rpcUrls": [],
+      "networkType": "testnet",
+      "relations": [
+        {
+          "kind": "testnetOf",
+          "network": "stellar"
+        }
+      ],
+      "services": {
+        "firehose": [
+          "testnet.stellar.streamingfast.io:443"
+        ],
+        "substreams": [
+          "testnet.stellar.streamingfast.io:443"
+        ]
+      },
+      "issuanceRewards": false,
+      "nativeToken": "XLM",
+      "docsUrl": "https://developers.stellar.org",
+      "firehose": {
+        "blockType": "sf.stellar.type.v1.Block",
+        "bufUrl": "https://buf.build/streamingfast/firehose-stellar",
+        "bytesEncoding": "base64",
+        "firstStreamableBlock": {
+          "id": "0x2ec9adddf7475dee37e8fd0cc0f07ae0893e2325db7fb25fb318e8b7a797a720",
+          "height": 200
+        }
+      },
+      "icon": {
+        "web3Icons": {
+          "name": "stellar"
+        }
+      }
+    },
+    {
+      "id": "tron",
+      "shortName": "TRON",
+      "fullName": "TRON Mainnet",
+      "aliases": [
+        "tron-mainnet"
+      ],
+      "caip2Id": "tron:mainnet",
+      "explorerUrls": [
+        "https://tronscan.org"
+      ],
+      "rpcUrls": [
+        "https://api.trongrid.io/jsonrpc",
+        "https://tron.drpc.org",
+        "https://rpc.ankr.com/tron_jsonrpc"
+      ],
+      "apiUrls": [
+        {
+          "url": "https://apilist.tronscanapi.com/api",
+          "kind": "other"
+        }
+      ],
+      "networkType": "mainnet",
+      "services": {
+        "subgraphs": [],
+        "sps": [],
+        "firehose": [
+          "mainnet.tron.streamingfast.io:443"
+        ],
+        "substreams": [
+          "mainnet.tron.streamingfast.io:443"
+        ]
+      },
+      "issuanceRewards": false,
+      "nativeToken": "TRX",
+      "docsUrl": "https://developers.tron.network",
+      "firehose": {
+        "blockType": "sf.tron.type.v1.Block",
+        "bufUrl": "https://buf.build/streamingfast/firehose-tron",
+        "bytesEncoding": "hex",
+        "firstStreamableBlock": {
+          "id": "0x00000000000000010ff5414c5cfbe9eae982e8cef7eb2399a39118e1206c8247",
+          "height": 1
+        }
+      },
+      "icon": {
+        "web3Icons": {
+          "name": "tron"
         }
       }
     }


### PR DESCRIPTION
- Update types to v0.7 schema
- Add `getNetworkByGraphId()` API
- Add `getNetworkByCaip2Id()` API
- Deprecate `getNetworkById()` and `getNetworkByAlias()` API
- Add linters
- Add CI